### PR TITLE
Add keyvault and labapi to settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -10,9 +10,7 @@
 rootProject.name = 'android_auth'
 
 include ':adal', ':msal', ':common', ':AADAuthenticator', ':brokerHost', ':msalTestApp', ':adalTestApp',
-        ':app', ':library', ':NgcProviderLibrary', ':AadRemoteNgcLibrary', ':SharedCoreLibrary',
-        ':keyvault', ':labapi'
-        ':app', ':library', ':NgcProviderLibrary', ':AadRemoteNgcLibrary', ':SharedCoreLibrary', ':AzureSample', ':TestUtilitiesLibrary'
+        ':app', ':library', ':NgcProviderLibrary', ':AadRemoteNgcLibrary', ':SharedCoreLibrary', ':AzureSample', ':TestUtilitiesLibrary', ':keyvault', ':labapi'
 project(':common').projectDir = new File('common/common')
 project(':msal').projectDir = new File('msal/msal')
 project(':adal').projectDir = new File('adal/adal')

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,8 @@
 rootProject.name = 'android_auth'
 
 include ':adal', ':msal', ':common', ':AADAuthenticator', ':brokerHost', ':msalTestApp', ':adalTestApp',
-        ':app', ':library', ':NgcProviderLibrary', ':AadRemoteNgcLibrary', ':SharedCoreLibrary', ':AzureSample', ':TestUtilitiesLibrary', ':keyvault', ':labapi'
+        ':app', ':library', ':NgcProviderLibrary', ':AadRemoteNgcLibrary', ':SharedCoreLibrary', ':AzureSample', ':TestUtilitiesLibrary',
+        ':labapi', ':keyvault'
 project(':common').projectDir = new File('common/common')
 project(':msal').projectDir = new File('msal/msal')
 project(':adal').projectDir = new File('adal/adal')
@@ -23,7 +24,7 @@ project(':library').projectDir = new File ('authenticator/PhoneFactor/OpenSource
 project(':NgcProviderLibrary').projectDir = new File ('authenticator/PhoneFactor/NgcProviderLibrary')
 project(':AadRemoteNgcLibrary').projectDir = new File ('authenticator/PhoneFactor/AadRemoteNgcLibrary')
 project(':SharedCoreLibrary').projectDir = new File ('authenticator/PhoneFactor/SharedCoreLibrary')
-project(':keyvault').projectDir = new File('adal/keyvault')
-project(':labapi').projectDir = new File('adal/labapi')
 project(':AzureSample').projectDir = new File ('azuresample/app')
 project(':TestUtilitiesLibrary').projectDir = new File ('authenticator/PhoneFactor/TestUtilitiesLibrary')
+project(':keyvault').projectDir = new File('common/keyvault')
+project(':labapi').projectDir = new File('common/labapi')

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,8 @@
 rootProject.name = 'android_auth'
 
 include ':adal', ':msal', ':common', ':AADAuthenticator', ':brokerHost', ':msalTestApp', ':adalTestApp',
-        ':app', ':library', ':NgcProviderLibrary', ':AadRemoteNgcLibrary', ':SharedCoreLibrary'
+        ':app', ':library', ':NgcProviderLibrary', ':AadRemoteNgcLibrary', ':SharedCoreLibrary',
+        ':keyvault', ':labapi'
 project(':common').projectDir = new File('common/common')
 project(':msal').projectDir = new File('msal/msal')
 project(':adal').projectDir = new File('adal/adal')
@@ -23,3 +24,5 @@ project(':library').projectDir = new File ('authenticator/PhoneFactor/OpenSource
 project(':NgcProviderLibrary').projectDir = new File ('authenticator/PhoneFactor/NgcProviderLibrary')
 project(':AadRemoteNgcLibrary').projectDir = new File ('authenticator/PhoneFactor/AadRemoteNgcLibrary')
 project(':SharedCoreLibrary').projectDir = new File ('authenticator/PhoneFactor/SharedCoreLibrary')
+project(':keyvault').projectDir = new File('adal/keyvault')
+project(':labapi').projectDir = new File('adal/labapi')


### PR DESCRIPTION
In this PR, I've added the keyvault and labapi projects to the global settings.gradle file so that they can be used in other subprojects as well. This allows us to utilize the keyvault and labapi for tests that are written in common, or msal or any other submodule. 

keyvault and labapi have also been moved from adal to common. You can take a look at the following PRs.

adal - https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1456
common - https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/609