### PR TITLE
Add robolectric and testutils module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:$rootProject.ext.gradleVersion"
+        classpath "com.android.tools.build:gradle:${rootProject.ext.gradleVersion}"
         classpath "net.serenity-bdd:serenity-gradle-plugin:1.9.6"
         classpath 'com.google.gms:google-services:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -12,6 +12,7 @@ ext {
     androidMavenGradlePluginVersion = "1.4.1"
 
     // Libraries
+    androidxTestCoreVersion = "1.2.0"
     androidxJunitVersion = "1.1.1"
     annotationVersion = "1.0.0"
     appCompatVersion = "1.0.2"
@@ -30,6 +31,7 @@ ext {
     nimbusVersion = "5.7"
     runnerVersion = "1.2.0"
     rulesVersion = "1.2.0"
+    robolectricVersion = "4.0"
 
     // TODO: adal automation test app.
     supportLibraryVersion = "27.1.+"

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ rootProject.name = 'android_auth'
 
 include ':adal', ':msal', ':common', ':AADAuthenticator', ':brokerHost', ':msalTestApp', ':adalTestApp',
         ':app', ':library', ':NgcProviderLibrary', ':AadRemoteNgcLibrary', ':SharedCoreLibrary', ':AzureSample', ':TestUtilitiesLibrary',
-        ':labapi', ':keyvault'
+        ':labapi', ':keyvault', ':testutils'
 project(':common').projectDir = new File('common/common')
 project(':msal').projectDir = new File('msal/msal')
 project(':adal').projectDir = new File('adal/adal')
@@ -28,3 +28,4 @@ project(':AzureSample').projectDir = new File ('azuresample/app')
 project(':TestUtilitiesLibrary').projectDir = new File ('authenticator/PhoneFactor/TestUtilitiesLibrary')
 project(':keyvault').projectDir = new File('common/keyvault')
 project(':labapi').projectDir = new File('common/labapi')
+project(':testutils').projectDir = new File('common/testutils')


### PR DESCRIPTION
In this PR, I've added the Robolectric version as well as the AndroidX Test Core Version to settings.gradle

I've also added the testutils module to settings.gradle

Related common PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/629

Related MSAL PR: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/732