### PR TITLE
Switching to IdentityDivision ADAL for Upstream Feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,11 @@ This repository contains a build gradle and git alias commands for building ADAL
 The android related auth projects pull artifacts from public and private package repositories.  The private artifacts are published using Azure DevOps.  You will need to generate
 and store the credentials for the Identity and Aria azure devops instances.
 
-- [Aria](https://msasg.visualstudio.com/Shared%20Data/_packaging?_a=package&feed=ARIA-SDK&package=com.microsoft.applications%3Aariaandroidjavasdk-release&version=3.0.22.0&protocolType=maven)
 - [Identity](https://identitydivision.visualstudio.com/DevEx/_packaging?_a=feed&feed=AndroidADAL)
-- [Intune](https://msazure.visualstudio.com/Intune/_packaging?_a=feed&feed=android-maven)
 
 1. Click the "Connect to feed" button.  
 2. Then select gradle.  
 3. Then click the generate credentials button
-
-- [PowerLift](https://office.visualstudio.com/_usersSettings/tokens) 
-1. Press “+ New token” and create a name for your token
-2. Under “Scopes” select “Custom Defined”, hit "See all scopes", check only “Packaging (read)”.
 
 - [AuthenticatorApp](https://msazure.visualstudio.com/One/_git/AD-MFA-phonefactor-phoneApp-android)
 1. Go to //myaccess
@@ -29,12 +23,7 @@ Then add the following to your gradle properties (in your user folder on windows
 
 ```gradle.properties
 vstsUsername=VSTS 
-vstsGradleAccessToken=<InsertIdentityAccessTokenHere>
 vstsMavenAccessToken=<InsertIdentityAccessTokenHere>
-vstsAriaGradleAccessToken=<InsertAriaAccessTokenHere>
-azureArtifactsGradleAccessToken=<InsertIntuneAccessTokenHere>
-powerliftUsername=<Your Alias>
-powerliftPassword=<InsertPowerLiftAccessTokenHere>
 ```
 >NOTE: The sample configuration produced by Azure DevOps changed when the service was renamed from Visual Studio Online to Azure DevOps... the vstsUsername VSTS is still accepted.  
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,5 @@
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
-project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME") : project.findProperty("vstsUsername")
 project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
-project.ext.ariaGradleAccessToken = System.getenv("ENV_VSTS_GRADLE_ANDROIDADACCOUNTS_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_GRADLE_ANDROIDADACCOUNTS_ACCESSTOKEN") : project.findProperty("vstsAriaGradleAccessToken")
-project.ext.msazureGradleAccessToken = System.getenv("AZURE_ARTIFACTS_ENV_ACCESS_TOKEN") != null ? System.getenv("AZURE_ARTIFACTS_ENV_ACCESS_TOKEN") : project.findProperty("azureArtifactsGradleAccessToken")
-project.ext.ariaTenantTokenTest = System.getenv("ENV_ARIA_ANDROIDADACCOUNTS_TOKENTEST") != null ? System.getenv("ENV_ARIA_ANDROIDADACCOUNTS_TOKENTEST") : project.findProperty("ariaTenantTokenTest")
-project.ext.ariaTenantTokenProd = System.getenv("ENV_ARIA_ANDROIDADACCOUNTS_TOKENPROD") != null ? System.getenv("ENV_ARIA_ANDROIDADACCOUNTS_TOKENPROD") : project.findProperty("ariaTenantTokenProd")
-ext.ariaPkgName = 'vsts-maven-aria-sdk'
-ext.ariaPkgUrl = 'https://msasg.pkgs.visualstudio.com/_packaging/ARIA-SDK/maven/v1'
 buildscript {
 
     ext.kotlin_version = '1.3.11'
@@ -64,16 +56,4 @@ if (!project.hasProperty("vstsUsername")) {
 }
 if (!project.hasProperty("vstsMavenAccessToken")) {
     logger.error('vstsMavenAccessToken is missing in gradle.properties')
-}
-if (!project.hasProperty("vstsGradleAccessToken")) {
-    logger.error('vstsGradleAccessToken is missing in gradle.properties')
-}
-if (!project.hasProperty("azureArtifactsGradleAccessToken")) {
-    logger.error('azureArtifactsGradleAccessToken is missing in gradle.properties')
-}
-if (!project.hasProperty("ariaTenantTokenProd")) {
-    logger.error('ariaTenantTokenProd is missing in gradle.properties')
-}
-if (!project.hasProperty("ariaTenantTokenTest")) {
-    logger.error('ariaTenantTokenTest is missing in gradle.properties')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ allprojects {
     repositories {
         mavenLocal()
         maven {
+            // msazure and aria are consumed via upstream sources of the AndroidADAL feed.
             name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {

--- a/build.gradle
+++ b/build.gradle
@@ -34,27 +34,11 @@ allprojects {
     repositories {
         mavenLocal()
         maven {
-            name "msazure"
-            url 'https://msazure.pkgs.visualstudio.com/_packaging/android-maven/maven/v1'
-            credentials {
-                username project.vstsUsername
-                password project.msazureGradleAccessToken
-            }
-        }
-        maven {
             name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
                 username project.vstsUsername
                 password project.vstsMavenAccessToken
-            }
-        }
-        maven {
-            name project.ariaPkgName
-            url project.ariaPkgUrl
-            credentials {
-                username project.vstsUsername
-                password project.ariaGradleAccessToken
             }
         }
         google()


### PR DESCRIPTION
Tito made a change to consolidate all of the dependencies in one upstream feed.

See: https://msazure.visualstudio.com/One/_git/AD-MFA-phonefactor-phoneApp-android/pullrequest/2206322?path=%2FPhoneFactor%2Fapp%2Fbuild.gradle&_a=overview