### PR TITLE
Changing the repository order to download dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ allprojects {
 
     repositories {
         mavenLocal()
+        google()
+        jcenter()
         maven {
             // msazure and aria are consumed via upstream sources of the AndroidADAL feed.
             name "vsts-maven-adal-android"
@@ -43,8 +45,7 @@ allprojects {
                 password project.vstsMavenAccessToken
             }
         }
-        google()
-        jcenter()
+
     }
 
     gradle.projectsEvaluated {


### PR DESCRIPTION
https://github.com/AzureAD/ad-accounts-for-android/pull/1293

Encountered problems with gradle while setting up android-complete, which hinted to search for a discrepancy in the repository order to download the dependencies.