### PR TITLE
Remove unused authenticator values

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -11,15 +11,6 @@ ext {
     gradleVersion = '3.6.1'
     androidMavenGradlePluginVersion = "1.4.1"
 
-    // AuthApp
-    androidx_work_version = "2.3.3"
-    com_android_installreferrer_installreferrer_version = "1.1.2"
-    com_android_tools_build_gradle_version = "3.6.1"
-    com_google_gms_google_services_version = "4.3.3"
-    com_google_firebase_firebase_core_version = "17.2.3"
-    com_google_firebase_firebase_messaging_version = "20.1.2"
-    kotlin_version = "1.3.70"
-
     // Libraries
     androidxTestCoreVersion = "1.2.0"
     androidxJunitVersion = "1.1.1"


### PR DESCRIPTION
These values are copied from authenticator a while back. 

Now, android_complete is configured in such a way that it would just read these values from authenticator's version file during build time, so these values are no longer needed.

(NOTE: the values here are outdated and it would crash authenticator app)