### PR TITLE
Adding ramp-up-mini as a submodule

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -9,10 +9,12 @@
 		git clone -b dev https://github.com/AzureAD/ad-accounts-for-android.git broker; \
 		git clone -b working https://msazure.visualstudio.com/DefaultCollection/One/_git/AD-MFA-phonefactor-phoneApp-android authenticator; \
         git clone -b dev https://github.com/Azure-Samples/ms-identity-android-java.git azuresample; \
+        git clone -b android-complete https://github.com/t-fadura/ramp-up-mini.git ramp-up-mini; \
 		cd msal; git submodule init; git submodule update; cd ..; \
 		cd adal; git submodule init; git submodule update; cd ..; \
 		cd broker; git submodule init; git submodule update; cd ..; \
 		cd authenticator; git submodule init; git submodule update; cd ..; \
+        cd ramp-up-mini; git submodule init; git submodule update; cd ..; \
 		workDir=$(pwd); \
 		git config --replace-all androidcomplete.workDir $workDir; \
 		}; f"

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ broker
 common
 authenticator
 azuresample
+ramp-up-mini
 
 # Gradle files
 .gradle/

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,7 +12,7 @@ rootProject.name = 'android_auth'
 // Android DevX Projects
 include ':adal', ':msal', ':common', ':AADAuthenticator',
         ':brokerHost', ':adalTestApp', ':msalTestApp', ':AzureSample', ':package-inspector', ':pop-benchmarker',
-        ':labapi', ':keyvault', ':testutils'
+        ':labapi', ':keyvault', ':testutils', ':ramp-up-mini'
 project(':adal').projectDir = new File('adal/adal')
 project(':msal').projectDir = new File('msal/msal')
 project(':common').projectDir = new File('common/common')
@@ -26,6 +26,7 @@ project(':pop-benchmarker').projectDir = new File('msal/pop-benchmarker')
 project(':labapi').projectDir = new File('common/labapi')
 project(':keyvault').projectDir = new File('common/keyvault')
 project(':testutils').projectDir = new File('common/testutils')
+project(':ramp-up-mini').projectDir = new File('ramp-up-mini/ramp-up-mini/app')
 
 // Authenticator projects
 include ':app', ':NgcProviderLibrary', ':AadRemoteNgcLibrary', ':SharedCoreLibrary', ':TestUtilitiesLibrary',

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,7 @@ project(':testutils').projectDir = new File('common/testutils')
 
 // Authenticator projects
 include ':app', ':NgcProviderLibrary', ':AadRemoteNgcLibrary', ':SharedCoreLibrary', ':TestUtilitiesLibrary',
-        ':3rdparty', ':PortableIdentityCard-ClientSDK', ':CommonUiLibrary'
+        ':3rdparty', ':PortableIdentityCard-ClientSDK', ':CommonUiLibrary', ':Brooklyn'
 project(':app').projectDir = new File('authenticator/PhoneFactor/app')
 project(':NgcProviderLibrary').projectDir = new File('authenticator/PhoneFactor/NgcProviderLibrary')
 project(':AadRemoteNgcLibrary').projectDir = new File('authenticator/PhoneFactor/AadRemoteNgcLibrary')
@@ -38,3 +38,4 @@ project(':TestUtilitiesLibrary').projectDir = new File('authenticator/PhoneFacto
 project(':3rdparty').projectDir = new File('authenticator/PhoneFactor/3rdparty')
 project(':PortableIdentityCard-ClientSDK').projectDir = new File('authenticator/PhoneFactor/PortableIdentityCard-ClientSDK-Android/PortableIdentityCard-ClientSDK')
 project(':CommonUiLibrary').projectDir = new File('authenticator/PhoneFactor/CommonUiLibrary')
+project(':Brooklyn').projectDir = new File('authenticator/PhoneFactor/Brooklyn')


### PR DESCRIPTION
Adding ramp-up-mini as a submodule in .gitconfig, .gitignore, and settings.gradle.

Please disregard this for now, it may be canceled as the submodule is configured a bit more.