### PR TITLE
Fixing Authenticator build after DID submodule rename

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -31,13 +31,13 @@ project(':uiautomationutilities').projectDir = new File('common/uiautomationutil
 
 // Authenticator projects
 include ':app', ':NgcProviderLibrary', ':AadRemoteNgcLibrary', ':SharedCoreLibrary', ':TestUtilitiesLibrary',
-        ':3rdparty', ':PortableIdentityCard-ClientSDK', ':CommonUiLibrary', ':Brooklyn'
+        ':3rdparty', ':VerifiableCredential-SDK', ':CommonUiLibrary', ':Brooklyn'
 project(':app').projectDir = new File('authenticator/PhoneFactor/app')
 project(':NgcProviderLibrary').projectDir = new File('authenticator/PhoneFactor/NgcProviderLibrary')
 project(':AadRemoteNgcLibrary').projectDir = new File('authenticator/PhoneFactor/AadRemoteNgcLibrary')
 project(':SharedCoreLibrary').projectDir = new File('authenticator/PhoneFactor/SharedCoreLibrary')
 project(':TestUtilitiesLibrary').projectDir = new File('authenticator/PhoneFactor/TestUtilitiesLibrary')
 project(':3rdparty').projectDir = new File('authenticator/PhoneFactor/3rdparty')
-project(':PortableIdentityCard-ClientSDK').projectDir = new File('authenticator/PhoneFactor/PortableIdentityCard-ClientSDK-Android/PortableIdentityCard-ClientSDK')
+project(':VerifiableCredential-SDK').projectDir = new File('authenticator/PhoneFactor/PortableIdentityCard-ClientSDK-Android/sdk')
 project(':CommonUiLibrary').projectDir = new File('authenticator/PhoneFactor/CommonUiLibrary')
 project(':Brooklyn').projectDir = new File('authenticator/PhoneFactor/Brooklyn')


### PR DESCRIPTION
PortableIdentityCard-ClientSDK (DID) renamed to VerifiableCredential-SDK