### PR TITLE
Add common-java

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -19,13 +19,14 @@ pluginManagement {
 rootProject.name = 'android_auth'
 
 // Android DevX Projects
-include ':adal', ':msal', ':common', ':AADAuthenticator',
+include ':adal', ':msal', ':common', ':common-java', ':AADAuthenticator',
         ':brokerHost', ':adalTestApp', ':msalTestApp', ':package-inspector', ':pop-benchmarker',
         ':labapi', ':keyvault', ':testutils', 'msalautomationapp', 'uiautomationutilities', 'brokerautomationapp',
         ':oneauth', ':oneauthtestapp', ':msalcpptesthost', ':AzureSample'//, ':tsl', ':AzureSample',
 project(':adal').projectDir = new File('adal/adal')
 project(':msal').projectDir = new File('msal/msal')
 project(':common').projectDir = new File('common/common')
+project(':common-java').projectDir = new File('common/common4j')
 project(':AADAuthenticator').projectDir = new File('broker/AADAuthenticator')
 project(':brokerHost').projectDir = new File('broker/userapp')
 project(':adalTestApp').projectDir = new File('adal/userappwithbroker')


### PR DESCRIPTION
related PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1300

Given that common-java are being consumed as source, android complete will not (yet) break *without* this change.

At some point, once we switch to the 'dependency' model, then this will be required.