### PR TITLE
Add spotbugs exclusion list

### DIFF
--- a/plugins/buildsystem/build.gradle
+++ b/plugins/buildsystem/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.microsoft.identity'
-version '0.1.0'
+version '0.1.1'
 
 
 pluginBundle {

--- a/plugins/buildsystem/changelog
+++ b/plugins/buildsystem/changelog
@@ -1,7 +1,8 @@
 Plugin Overview: https://github.com/AzureAD/android-complete/blob/master/plugins/buildsystem/docs/Overview.md
 
-vNext
+Version 0.1.1
 ----------------------------
+[MINOR] Add exclude list to SpotBugs Plugin
 
 Version 0.1.0
 ----------------------------

--- a/plugins/buildsystem/src/main/java/com/microsoft/identity/buildsystem/SpotBugs.java
+++ b/plugins/buildsystem/src/main/java/com/microsoft/identity/buildsystem/SpotBugs.java
@@ -34,6 +34,7 @@ import java.io.File;
  */
 public final class SpotBugs {
     private static final String BASELINE_FILE_PATH_RELATIVE_TO_PROJECT_ROOT = "../config/spotbugs/baseline.xml";
+    private static final String EXCLUDE_FILE_PATH_RELATIVE_TO_PROJECT_ROOT = "../config/spotbugs/exclude.xml";
 
     /**
      * Applies theo  SpotBugs Plugin to given project
@@ -49,6 +50,11 @@ public final class SpotBugs {
         final File baselineFile = project.file(BASELINE_FILE_PATH_RELATIVE_TO_PROJECT_ROOT);
         if(baselineFile.exists()) {
             spotBugsExtension.getBaselineFile().set(baselineFile);
+        }
+
+        final File excludeFile = project.file(EXCLUDE_FILE_PATH_RELATIVE_TO_PROJECT_ROOT);
+        if (excludeFile.exists()) {
+            spotBugsExtension.getExcludeFilter().set(excludeFile);
         }
     }
 }


### PR DESCRIPTION
Spotbugs plugin will now filter out anything that matches with the provided filter in ../config/spotbugs/exclude.xml

for example, I'm going to exclude RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE warning (related PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1390)