### PR TITLE
BrokerHost pipeline from Android-Complete

### DIFF
--- a/azure-pipelines/build-android-complete.yml
+++ b/azure-pipelines/build-android-complete.yml
@@ -1,0 +1,47 @@
+# File: azure-pipelines\pull-request-validation\common4j.yml
+# Description: Run test in common4j
+name: $(date:yyyyMMdd)$(rev:.r)
+
+trigger: none
+
+resources:
+  repositories:
+    - repository: self
+      type: git
+      ref: master
+    - repository: common
+      type: github
+      name: AzureAD/microsoft-authentication-library-common-for-android
+      ref: dev
+      endpoint: ANDROID_GITHUB
+
+pool:
+  name: Hosted Windows 2019 with VS2019
+
+jobs:
+  - job: Checkout
+    displayName: Checkout
+    steps:
+      - checkout: self
+        clean: true
+        submodules: recursive
+        persistCredentials: True
+      - template: ../templates/steps/automation-cert.yml
+      - task: Gradle@1
+        name: Gradle1
+        displayName: Assembles the outputs of this project.
+        inputs:
+          tasks: clean common4j:assemble
+      - task: ComponentGovernanceComponentDetection@0
+        displayName: Component Detection
+  - job: droidSetup
+    displayName: Perform droidSetup
+    steps:
+      - powershell: |
+          # Include the .gitconfig file included with project to your local gitconfig
+          git config --local include.path ../.gitconfig
+          # Run this newly minted command to clone each repo as a subfolder
+          git droidSetupDevexOnly
+        errorActionPreference: continue
+        displayName: 'Setup Android Complete'
+...

--- a/azure-pipelines/build-android-complete.yml
+++ b/azure-pipelines/build-android-complete.yml
@@ -1,47 +1,122 @@
-# File: azure-pipelines\pull-request-validation\common4j.yml
-# Description: Run test in common4j
+# File: azure-pipelines\build-android-complete.yml
+# Description: Generate BrokerHost APK
+# use <project>_branch variables to build the Local version
+# use <project>_version variables to build the Dist version
+# Variable '[adal, common, msal, ad_accounts]_branch' was defined in the Variables tab
+# Variable '[adal, common, msal, ad_accounts]_version' was defined in the Variables tab
+# Variable: 'ENV_VSTS_MVN_ANDROID_MSAL_USERNAME' was defined in the Variables tab
+# Variable: 'mvnAccessToken' was defined in the Variables tab
+# https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
 name: $(date:yyyyMMdd)$(rev:.r)
 
 trigger: none
+pr: none
+
+parameters:
+- name: productFlavors
+  displayName: Product Flavor
+  type: string
+  default: Local
+  values:
+  - Local
+  - Dist
+- name: signingConfigurations
+  displayName: Signing Configuration
+  type: string
+  default: Debug
+  values:
+  - Debug
+  - Release
 
 resources:
   repositories:
-    - repository: self
-      type: git
-      ref: master
-    - repository: common
-      type: github
-      name: AzureAD/microsoft-authentication-library-common-for-android
-      ref: dev
-      endpoint: ANDROID_GITHUB
-
-pool:
-  name: Hosted Windows 2019 with VS2019
+  - repository: common
+    type: github
+    name: AzureAD/microsoft-authentication-library-common-for-android
+    ref: $(common_branch)
+    endpoint: ANDROID_GITHUB
+  - repository: msal
+    type: github
+    name: AzureAD/microsoft-authentication-library-for-android
+    ref: $(msal_branch)
+    endpoint: ANDROID_GITHUB
+  - repository: adal
+    type: github
+    name: AzureAD/azure-activedirectory-library-for-android
+    ref: $(adal_branch)
+    endpoint: ANDROID_GITHUB
+  - repository: broker
+    type: github
+    name: AzureAD/ad-accounts-for-android
+    ref: $(ad_accounts_branch)
+    endpoint: ANDROID_GITHUB
 
 jobs:
-  - job: Checkout
-    displayName: Checkout
-    steps:
-      - checkout: self
-        clean: true
-        submodules: recursive
-        persistCredentials: True
-      - template: ../templates/steps/automation-cert.yml
-      - task: Gradle@1
-        name: Gradle1
-        displayName: Assembles the outputs of this project.
-        inputs:
-          tasks: clean common4j:assemble
-      - task: ComponentGovernanceComponentDetection@0
-        displayName: Component Detection
-  - job: droidSetup
-    displayName: Perform droidSetup
-    steps:
-      - powershell: |
-          # Include the .gitconfig file included with project to your local gitconfig
-          git config --local include.path ../.gitconfig
-          # Run this newly minted command to clone each repo as a subfolder
-          git droidSetupDevexOnly
-        errorActionPreference: continue
-        displayName: 'Setup Android Complete'
+- job: brokerhost
+  displayName: Build BrokerHost ${{ parameters.productFlavors }} ${{ parameters.signingConfigurations }} APK
+  pool:
+    name: Hosted Windows 2019 with VS2019
+  steps:
+  - checkout: self
+    clean: true
+    path: android-complete
+  - checkout: common
+    clean: true
+    path: android-complete/common
+  - checkout: msal
+    clean: true
+    submodules: true
+    path: android-complete/msal
+  - checkout: adal
+    clean: true
+    submodules: true
+    path: android-complete/adal
+  - checkout: broker
+    clean: true
+    submodules: true
+    path: android-complete/broker
+  - ${{ if eq(parameters.productFlavors, 'Dist') }}:
+    - task: PowerShell@2
+      displayName: Generate Assemble Dist Task
+      inputs:
+        targetType: inline
+        script: |
+          $assembleTask = "assembleDist${{ parameters.signingConfigurations }}"
+          if (("$(common_version)" -ne "")) {
+              $assembleTask = $assembleTask + " -PcommonVersion=" + "$(common_version)"
+          }
+          if (("$(ad_accounts_version)" -ne "")) {
+              $assembleTask = $assembleTask + " -PadAccountsVersion=" + "$(ad_accounts_version)"
+          }
+          if (("$(adal_version)" -ne "")) {
+              $assembleTask = $assembleTask + " -PadalVersion=" + "$(adal_version)"
+          }
+          if (("$(msal_version)" -ne "")) {
+              $assembleTask = $assembleTask + " -PmsalVersion=" + "$(msal_version)"
+          }
+          Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
+  - ${{ if eq(parameters.productFlavors, 'Local') }}:
+    - pwsh: echo "##vso[task.setvariable variable=AssembleTask;]assembleLocal${{ parameters.signingConfigurations }}"
+      displayName: Generate Assemble Local Task
+  - task: CmdLine@1
+    displayName: Set MVN AccessToken in Environment
+    inputs:
+      filename: echo
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(mvnAccessToken)'
+  - task: Gradle@1
+    name: Gradle1
+    displayName: Assemble BrokerHost
+    inputs:
+      tasks: brokerHost:clean brokerHost:$(AssembleTask)
+      publishJUnitResults: false
+      jdkArchitecture: x86
+      sqAnalysisBreakBuildIfQualityGateFailed: false
+      gradleWrapperFile: $(Agent.BuildDirectory)/android-complete/gradlew
+      cwd: $(Agent.BuildDirectory)/android-complete
+  - task: PublishPipelineArtifact@1
+    displayName: Publish Broker Host APK
+    inputs:
+      targetPath: C:/temp/android_auth/brokerHost/outputs/apk/${{ lower(parameters.productFlavors) }}/${{ lower(parameters.signingConfigurations) }}
+      artifactName: BrokerHost
+      patterns: '**/*.apk'
 ...

--- a/azure-pipelines/build-broker-host.yml
+++ b/azure-pipelines/build-broker-host.yml
@@ -1,4 +1,4 @@
-# File: azure-pipelines\build-android-complete.yml
+# File: azure-pipelines\build-broker-host.yml
 # Description: Generate BrokerHost APK
 # use <project>_branch variables to build the Local version
 # use <project>_version variables to build the Dist version


### PR DESCRIPTION
Pipeline that build brokerHost from android-complete, if we try to build the local version from ad-accounts this will result in a misleading build that is using dist dependencies  

    if (findProject(':adal') != null) {
        localApi(project(':adal')) {
            exclude module: 'common'
        }
        distApi(group: 'com.microsoft.aad', name: 'adal', version: "${adalDistVersion}") {
            exclude module: 'common'
        }
    } else {
        api(group: 'com.microsoft.aad', name: 'adal', version: "${adalDistVersion}") {
            exclude module: 'common'
        }
    }

Pipeline: https://identitydivision.visualstudio.com/Engineering/_build?definitionId=1432&_a=summary