### PR TITLE
Jacoco initialization issue fix

### DIFF
--- a/plugins/buildsystem/build.gradle
+++ b/plugins/buildsystem/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'com.microsoft.identity'
-version '0.2.1'
+version '0.2.2'
 
 
 pluginBundle {

--- a/plugins/buildsystem/changelog
+++ b/plugins/buildsystem/changelog
@@ -1,5 +1,9 @@
 Plugin Overview: https://github.com/AzureAD/android-complete/blob/master/plugins/buildsystem/docs/Overview.md
 
+Version 0.2.2
+----------------------------
+[MINOR] Fixed the issue with initializing Jacoco
+
 Version 0.2.0
 ----------------------------
 [MINOR] Added ability to generate code coverage tasks

--- a/plugins/buildsystem/src/main/java/com/microsoft/identity/buildsystem/codecov/CodeCoverage.kt
+++ b/plugins/buildsystem/src/main/java/com/microsoft/identity/buildsystem/codecov/CodeCoverage.kt
@@ -63,6 +63,17 @@ object CodeCoverage {
      * Apply some plugin configuration from [CodeCoverageReportExtension] to the project.
      */
     private fun Project.configure() {
+        if (isAndroidProject(this)) {
+            // need to create below file so that jacoco is properly initialized during instrumented tests
+            // see https://github.com/jacoco/jacoco/issues/968 for more details
+            val androidTestResourcesDirectory = project.file("src/androidTest/resources")
+            val jacocoAgentProperties = File(androidTestResourcesDirectory, "jacoco-agent.properties")
+            if (!jacocoAgentProperties.exists()) {
+                androidTestResourcesDirectory.mkdirs()
+                jacocoAgentProperties.writeText("output=none")
+            }
+        }
+
         project.plugins.apply(JacocoPlugin::class.java)
 
         project.extensions.findByType(JacocoPluginExtension::class.java)?.apply {
@@ -93,15 +104,6 @@ object CodeCoverage {
         }
 
         if (reportExtension.androidTests.enabled) {
-            // need to create below file so that jacoco is properly initialized during instrumented tests
-            // see https://github.com/jacoco/jacoco/issues/968 for more details
-            val androidTestResourcesDirectory = project.file("src/androidTest/resources")
-            val jacocoAgentProperties = File(androidTestResourcesDirectory, "jacoco-agent.properties")
-            if (!jacocoAgentProperties.exists()) {
-                androidTestResourcesDirectory.mkdirs()
-                jacocoAgentProperties.writeText("output=none")
-            }
-
             createTasks(project, TestTypes.AndroidTest)
         }
     }


### PR DESCRIPTION
- This fixes issues caused by the first version of the code coverage tool specifically in instrumented tests
- The issue is that jacoco is not initialized properly when running the some unit tests
- The fix follows this -https://github.com/jacoco/jacoco/issues/968