### PR TITLE
Pipeline to assemble and publish dev builds for auth client android sdk libraries

### DIFF
--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -12,6 +12,10 @@ trigger: none
 schedules:
   - cron: "0 22 * * 1-5" # 10 PM everyday Mon-Fri
     displayName: Auth Client Android SDK dev build
+    branches:
+      include:
+      - master
+    always: true
 
 resources:
   repositories:
@@ -38,6 +42,7 @@ resources:
 
 variables:
   versionNumber: $(Build.BuildNumber)
+  gradleParams: '-PprojVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber) -PdistBroker4jVersion=$(versionNumber) -PdistCommonVersion=$(versionNumber)'
 
 pool:
   vmImage: ubuntu-latest
@@ -50,21 +55,24 @@ stages:
   jobs:
     - job: publishCommonLibraries
       displayName: Build and publish common4j and android common to internal maven feed
-      variables:
-        ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME: $(mvnUserName)
-        ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN: $(mvnAccessToken)
       steps:
       - checkout: common
         persistCredentials: True
         clean: true
       - task: Gradle@3
         displayName: Build and publish common4j
+        env:
+          ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME: $(mvnUserName)
+          ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN: $(mvnAccessToken)
         inputs:
-          tasks: common4j:assemble -PprojVersion=$(versionNumber) common4j:publishAarPublicationToVsts-maven-adal-androidRepository -PprojVersion=$(versionNumber)
+          tasks: common4j:assemble $(gradleParams) common4j:publish $(gradleParams)
       - task: Gradle@3
         displayName: Build and publish android common
+        env:
+          ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME: $(mvnUserName)
+          ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN: $(mvnAccessToken)
         inputs:
-          tasks: common:assembleDist -PprojVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber) common:publishDistReleasePublicationToVsts-maven-adal-androidRepository -PprojVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber)
+          tasks: common:assembleDist $(gradleParams) common:publishDistReleasePublicationToVsts-maven-adal-androidRepository $(gradleParams)
 - stage: 'publishBrokerLibraries'
   displayName: Broker - Build and publish
   dependsOn: publishCommonLibraries
@@ -73,24 +81,30 @@ stages:
   jobs:
     - job: publishBrokerLibraries
       displayName: Build and publish broker4j, android broker and linux broker libraries to internal maven feed
-      variables:
-        ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(mvnUserName)
-        ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(mvnAccessToken)
       steps:
-        - checkout: self
+        - checkout: broker
           persistCredentials: True
         - task: Gradle@3
           displayName: Build and publish broker4j
+          env:
+            ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(mvnUserName)
+            ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(mvnAccessToken)
           inputs:
-            tasks: broker4j:assemble -PprojVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber) broker4j:publishAarPublicationToVsts-maven-adal-androidRepository -PprojVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber)
+            tasks: broker4j:assemble $(gradleParams) broker4j:publishAarPublicationToVsts-maven-adal-androidRepository $(gradleParams)
         - task: Gradle@3
           displayName: Build and publish android broker
+          env:
+            ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(mvnUserName)
+            ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(mvnAccessToken)
           inputs:
-            tasks: AADAuthenticator:assembleDist -PprojVersion=$(versionNumber) -PdistBroker4jVersion=$(versionNumber) -PdistCommonVersion=$(versionNumber) AADAuthenticator:publishAdAccountsPublicationToVsts-maven-adal-androidRepository -PprojVersion=$(versionNumber) -PdistBroker4jVersion=$(versionNumber) -PdistCommonVersion=$(versionNumber)
+            tasks: AADAuthenticator:assembleDist $(gradleParams) AADAuthenticator:publishAdAccountsPublicationToVsts-maven-adal-androidRepository $(gradleParams)
         - task: Gradle@3
           displayName: Build and publish linux broker
+          env:
+            ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(mvnUserName)
+            ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(mvnAccessToken)
           inputs:
-            tasks: linuxBroker:assemble -PprojVersion=$(versionNumber) -PdistBroker4jVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber) linuxBroker:publishAarPublicationToVsts-maven-adal-androidRepository -PdistBroker4jVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber)
+            tasks: linuxBroker:assemble $(gradleParams) linuxBroker:publishAarPublicationToVsts-maven-adal-androidRepository $(gradleParams)
 - stage: 'publishMsal'
   displayName: Msal - Build and publish
   dependsOn: publishCommonLibraries
@@ -99,16 +113,16 @@ stages:
   jobs:
   - job: publishAndroidMsal
     displayName: Build and publish msal for android to internal maven feed
-    variables:
-      ENV_VSTS_MVN_ANDROID_MSAL_USERNAME: $(mvnUserName)
-      ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN: $(mvnAccessToken)
     steps:
       - checkout: msal
         persistCredentials: True
       - task: Gradle@3
         displayName: Build and publish msal
+        env:
+          ENV_VSTS_MVN_ANDROID_MSAL_USERNAME: $(mvnUserName)
+          ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN: $(mvnAccessToken)
         inputs:
-          tasks: msal:assembleDist -PprojVersion=$(versionNumber) -PdistCommonVersion=$(versionNumber) msal:publishMsalPublicationToVsts-maven-adal-androidRepository -PprojVersion=$(versionNumber) -PdistCommonVersion=$(versionNumber)
+          tasks: msal:assembleDistRelease $(gradleParams) msal:publishMsalPublicationToVsts-maven-adal-androidRepository $(gradleParams)
 - stage: 'publishAdal'
   displayName: Adal - Build and publish
   dependsOn: publishCommonLibraries
@@ -117,15 +131,14 @@ stages:
   jobs:
   - job: publishAndroidAdal
     displayName: Build and publish adal for android to internal maven feed
-    variables:
-      ENV_VSTS_MVN_ANDROIDADAL_USERNAME: $(mvnUserName)
-      ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN: $(mvnAccessToken)
     steps:
       - checkout: adal
         persistCredentials: True
       - task: Gradle@3
         displayName: Build and publish adal
-        enabled: false
+        env:
+          ENV_VSTS_MVN_ANDROIDADAL_USERNAME: $(mvnUserName)
+          ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN: $(mvnAccessToken)
         inputs:
-          tasks: adal:assembleDist -PprojVersion=$(versionNumber) -PdistCommonVersion=$(versionNumber) adal:publishAdalPublicationToVsts-maven-adal-androidRepository -PprojVersion=$(versionNumber) -PdistCommonVersion=$(versionNumber)
+          tasks: adal:assembleDist $(gradleParams) adal:publishAdalPublicationToVsts-maven-adal-androidRepository $(gradleParams)
 ...

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -42,7 +42,10 @@ resources:
 
 variables:
   versionNumber: $(Build.BuildNumber)
-  gradleParams: '-PprojVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber) -PdistBroker4jVersion=$(versionNumber) -PdistCommonVersion=$(versionNumber)'
+  projVersionParam: -PprojVersion=$(versionNumber)
+  common4jVersionParam: -PdistCommon4jVersion=$(versionNumber)
+  broker4jVersionParam: -PdistBroker4jVersion=$(versionNumber)
+  commonVersionParam: -PdistCommonVersion=$(versionNumber)
 
 pool:
   vmImage: ubuntu-latest
@@ -65,14 +68,14 @@ stages:
           ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME: $(mvnUserName)
           ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN: $(mvnAccessToken)
         inputs:
-          tasks: common4j:assemble $(gradleParams) common4j:publish $(gradleParams)
+          tasks: common4j:assemble $(projVersionParam) common4j:publish $(projVersionParam)
       - task: Gradle@3
         displayName: Build and publish android common
         env:
           ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME: $(mvnUserName)
           ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN: $(mvnAccessToken)
         inputs:
-          tasks: common:assembleDist $(gradleParams) common:publishDistReleasePublicationToVsts-maven-adal-androidRepository $(gradleParams)
+          tasks: common:assembleDist $(projVersionParam) $(common4jVersionParam) common:publishDistReleasePublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(common4jVersionParam)
 - stage: 'publishBrokerLibraries'
   displayName: Broker - Build and publish
   dependsOn: publishCommonLibraries
@@ -90,21 +93,21 @@ stages:
             ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(mvnUserName)
             ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(mvnAccessToken)
           inputs:
-            tasks: broker4j:assemble $(gradleParams) broker4j:publishAarPublicationToVsts-maven-adal-androidRepository $(gradleParams)
+            tasks: broker4j:assemble $(projVersionParam) $(common4jVersionParam) broker4j:publishAarPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(common4jVersionParam)
         - task: Gradle@3
           displayName: Build and publish android broker
           env:
             ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(mvnUserName)
             ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(mvnAccessToken)
           inputs:
-            tasks: AADAuthenticator:assembleDist $(gradleParams) AADAuthenticator:publishAdAccountsPublicationToVsts-maven-adal-androidRepository $(gradleParams)
+            tasks: AADAuthenticator:assembleDist $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam) AADAuthenticator:publishAdAccountsPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
         - task: Gradle@3
           displayName: Build and publish linux broker
           env:
             ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(mvnUserName)
             ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(mvnAccessToken)
           inputs:
-            tasks: linuxBroker:assemble $(gradleParams) linuxBroker:publishAarPublicationToVsts-maven-adal-androidRepository $(gradleParams)
+            tasks: linuxBroker:assemble $(projVersionParam) $(broker4jVersionParam) linuxBroker:publishAarPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(broker4jVersionParam)
 - stage: 'publishMsal'
   displayName: Msal - Build and publish
   dependsOn: publishCommonLibraries
@@ -122,7 +125,7 @@ stages:
           ENV_VSTS_MVN_ANDROID_MSAL_USERNAME: $(mvnUserName)
           ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN: $(mvnAccessToken)
         inputs:
-          tasks: msal:assembleDistRelease $(gradleParams) msal:publishMsalPublicationToVsts-maven-adal-androidRepository $(gradleParams)
+          tasks: msal:assembleDistRelease $(projVersionParam) $(commonVersionParam) msal:publishMsalPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(commonVersionParam)
 - stage: 'publishAdal'
   displayName: Adal - Build and publish
   dependsOn: publishCommonLibraries
@@ -140,5 +143,5 @@ stages:
           ENV_VSTS_MVN_ANDROIDADAL_USERNAME: $(mvnUserName)
           ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN: $(mvnAccessToken)
         inputs:
-          tasks: adal:assembleDist $(gradleParams) adal:publishAdalPublicationToVsts-maven-adal-androidRepository $(gradleParams)
+          tasks: adal:assembleDist $(projVersionParam) $(commonVersionParam) adal:publishAdalPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(commonVersionParam)
 ...

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -1,0 +1,131 @@
+# File: azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+# Description: Assemble & publish dev builds of auth client android sdk libraries to internal maven feed
+#  Libraries include common4j, common, broker4j, broker, msal and adal
+# Variable: 'mvnUserName' user name to access internal maven feed
+# Variable: 'mvnAccessToken' access token to access internal maven feed
+
+name: 0.0.$(Date:yyyyMMdd)-dev$(Rev:.r) # $(Build.BuildNumber) = name
+
+pr: none
+trigger: none
+
+schedules:
+  - cron: "0 22 * * 1-5" # 10 PM everyday Mon-Fri
+    displayName: Auth Client Android SDK dev build
+
+resources:
+  repositories:
+    - repository: common
+      type: github
+      name: AzureAD/microsoft-authentication-library-common-for-android
+      ref: $(commonBranch)
+      endpoint: ANDROID_GITHUB
+    - repository: broker
+      type: github
+      name: AzureAD/ad-accounts-for-android
+      ref: $(brokerBranch)
+      endpoint: ANDROID_GITHUB
+    - repository: msal
+      type: github
+      name: AzureAD/microsoft-authentication-library-for-android
+      ref: $(msalBranch)
+      endpoint: ANDROID_GITHUB
+    - repository: adal
+      type: github
+      name: AzureAD/azure-activedirectory-library-for-android
+      ref: $(adalBranch)
+      endpoint: ANDROID_GITHUB
+
+variables:
+  versionNumber: $(Build.BuildNumber)
+
+pool:
+  vmImage: ubuntu-latest
+
+stages:
+- stage: 'publishCommonLibraries'
+  displayName: Common - Build and publish
+  pool:
+    vmImage: ubuntu-latest
+  jobs:
+    - job: publishCommonLibraries
+      displayName: Build and publish common4j and android common to internal maven feed
+      variables:
+        ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME: $(mvnUserName)
+        ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN: $(mvnAccessToken)
+      steps:
+      - checkout: common
+        persistCredentials: True
+        clean: true
+      - task: Gradle@3
+        displayName: Build and publish common4j
+        inputs:
+          tasks: common4j:assemble -PprojVersion=$(versionNumber) common4j:publishAarPublicationToVsts-maven-adal-androidRepository -PprojVersion=$(versionNumber)
+      - task: Gradle@3
+        displayName: Build and publish android common
+        inputs:
+          tasks: common:assembleDist -PprojVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber) common:publishDistReleasePublicationToVsts-maven-adal-androidRepository -PprojVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber)
+- stage: 'publishBrokerLibraries'
+  displayName: Broker - Build and publish
+  dependsOn: publishCommonLibraries
+  pool:
+    vmImage: ubuntu-latest
+  jobs:
+    - job: publishBrokerLibraries
+      displayName: Build and publish broker4j, android broker and linux broker libraries to internal maven feed
+      variables:
+        ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(mvnUserName)
+        ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(mvnAccessToken)
+      steps:
+        - checkout: self
+          persistCredentials: True
+        - task: Gradle@3
+          displayName: Build and publish broker4j
+          inputs:
+            tasks: broker4j:assemble -PprojVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber) broker4j:publishAarPublicationToVsts-maven-adal-androidRepository -PprojVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber)
+        - task: Gradle@3
+          displayName: Build and publish android broker
+          inputs:
+            tasks: AADAuthenticator:assembleDist -PprojVersion=$(versionNumber) -PdistBroker4jVersion=$(versionNumber) -PdistCommonVersion=$(versionNumber) AADAuthenticator:publishAdAccountsPublicationToVsts-maven-adal-androidRepository -PprojVersion=$(versionNumber) -PdistBroker4jVersion=$(versionNumber) -PdistCommonVersion=$(versionNumber)
+        - task: Gradle@3
+          displayName: Build and publish linux broker
+          inputs:
+            tasks: linuxBroker:assemble -PprojVersion=$(versionNumber) -PdistBroker4jVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber) linuxBroker:publishAarPublicationToVsts-maven-adal-androidRepository -PdistBroker4jVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber)
+- stage: 'publishMsal'
+  displayName: Msal - Build and publish
+  dependsOn: publishCommonLibraries
+  pool:
+    vmImage: ubuntu-latest
+  jobs:
+  - job: publishAndroidMsal
+    displayName: Build and publish msal for android to internal maven feed
+    variables:
+      ENV_VSTS_MVN_ANDROID_MSAL_USERNAME: $(mvnUserName)
+      ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN: $(mvnAccessToken)
+    steps:
+      - checkout: msal
+        persistCredentials: True
+      - task: Gradle@3
+        displayName: Build and publish msal
+        inputs:
+          tasks: msal:assembleDist -PprojVersion=$(versionNumber) -PdistCommonVersion=$(versionNumber) msal:publishMsalPublicationToVsts-maven-adal-androidRepository -PprojVersion=$(versionNumber) -PdistCommonVersion=$(versionNumber)
+- stage: 'publishAdal'
+  displayName: Adal - Build and publish
+  dependsOn: publishCommonLibraries
+  pool:
+    vmImage: ubuntu-latest
+  jobs:
+  - job: publishAndroidAdal
+    displayName: Build and publish adal for android to internal maven feed
+    variables:
+      ENV_VSTS_MVN_ANDROIDADAL_USERNAME: $(mvnUserName)
+      ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN: $(mvnAccessToken)
+    steps:
+      - checkout: adal
+        persistCredentials: True
+      - task: Gradle@3
+        displayName: Build and publish adal
+        enabled: false
+        inputs:
+          tasks: adal:assembleDist -PprojVersion=$(versionNumber) -PdistCommonVersion=$(versionNumber) adal:publishAdalPublicationToVsts-maven-adal-androidRepository -PprojVersion=$(versionNumber) -PdistCommonVersion=$(versionNumber)
+...

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -107,7 +107,7 @@ stages:
             ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(mvnUserName)
             ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(mvnAccessToken)
           inputs:
-            tasks: linuxBroker:assemble $(projVersionParam) $(broker4jVersionParam) linuxBroker:publishAarPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(broker4jVersionParam)
+            tasks: linuxBroker:assemble $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam) linuxBroker:publishAarPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
 - stage: 'publishMsal'
   displayName: Msal - Build and publish
   dependsOn: publishCommonLibraries


### PR DESCRIPTION
### What
Adding a new pipeline to assemble & publish dev builds of auth client android sdk libraries to internal maven feed daily

### Why
The idea is to have daily dev builds for our libraries generated. These can be consumed 
- By Authenticator and CP to do continuous integration/verification and generate Apks for Broker testing
- By us to run our broker automation runs with Authenticator and CP Apks generated using these published artifacts
- By other partners (e.g. Teams) to do continuous integration and verifications
- For any local testing with daily dev builds

### How
The pipeline Builds latest code from dev branches for Common, Broker, Msal and Adal and publishes following libraries to Internal Maven: common4j, common, broker4j, broker, msal and adal
The version number for the generated libraries will be of the format 0.0.$(Date:yyyyMMdd)-dev$(Rev:.r).. e.g. 0.0.20211201-dev.1

### Testing
Sample run with the pipeline: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=852074&view=results