### PR TITLE
Enable ComponentGovernance detection for android components via gradle lockfile

### DIFF
--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -10,7 +10,7 @@ pr: none
 trigger: none
 
 schedules:
-  - cron: "0 22 * * 1-5" # 10 PM everyday Mon-Fri
+  - cron: "0 6 * * 1-6" # 6:00 AM UTC everyday Mon-Sat
     displayName: Auth Client Android SDK dev build
     branches:
       include:
@@ -46,6 +46,8 @@ variables:
   common4jVersionParam: -PdistCommon4jVersion=$(versionNumber)
   broker4jVersionParam: -PdistBroker4jVersion=$(versionNumber)
   commonVersionParam: -PdistCommonVersion=$(versionNumber)
+  androidProjectDependencyParam: --configuration=distReleaseRuntimeClasspath --write-locks
+  javaProjectDependencyParam: --configuration=runtimeClasspath --write-locks
 
 pool:
   vmImage: ubuntu-latest
@@ -69,13 +71,16 @@ stages:
           ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN: $(mvnAccessToken)
         inputs:
           tasks: common4j:assemble $(projVersionParam) common4j:publish $(projVersionParam)
+                 common4j:dependencies $(javaProjectDependencyParam)
       - task: Gradle@3
         displayName: Build and publish android common
         env:
           ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME: $(mvnUserName)
           ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN: $(mvnAccessToken)
         inputs:
-          tasks: common:assembleDist $(projVersionParam) $(common4jVersionParam) common:publishDistReleasePublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(common4jVersionParam)
+          tasks: common:assembleDist $(projVersionParam) $(common4jVersionParam)
+                 common:publishDistReleasePublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(common4jVersionParam)
+                 common:dependencies $(androidProjectDependencyParam) $(projVersionParam) $(common4jVersionParam)
 - stage: 'publishBrokerLibraries'
   displayName: Broker - Build and publish
   dependsOn: publishCommonLibraries
@@ -93,21 +98,27 @@ stages:
             ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(mvnUserName)
             ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(mvnAccessToken)
           inputs:
-            tasks: broker4j:assemble $(projVersionParam) $(common4jVersionParam) broker4j:publishAarPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(common4jVersionParam)
+            tasks: broker4j:assemble $(projVersionParam) $(common4jVersionParam)
+                   broker4j:publishAarPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(common4jVersionParam)
+                   broker4j:dependencies $(javaProjectDependencyParam)
         - task: Gradle@3
           displayName: Build and publish android broker
           env:
             ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(mvnUserName)
             ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(mvnAccessToken)
           inputs:
-            tasks: AADAuthenticator:assembleDist $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam) AADAuthenticator:publishAdAccountsPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
+            tasks: AADAuthenticator:assembleDist $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
+                   AADAuthenticator:publishAdAccountsPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
+                   AADAuthenticator:dependencies $(androidProjectDependencyParam)
         - task: Gradle@3
           displayName: Build and publish linux broker
           env:
             ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(mvnUserName)
             ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(mvnAccessToken)
           inputs:
-            tasks: linuxBroker:assemble $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam) linuxBroker:publishAarPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
+            tasks: linuxBroker:assemble $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
+                   linuxBroker:publishAarPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
+                   linuxBroker:dependencies $(javaProjectDependencyParam)
 - stage: 'publishMsal'
   displayName: Msal - Build and publish
   dependsOn: publishCommonLibraries
@@ -125,7 +136,9 @@ stages:
           ENV_VSTS_MVN_ANDROID_MSAL_USERNAME: $(mvnUserName)
           ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN: $(mvnAccessToken)
         inputs:
-          tasks: msal:assembleDistRelease $(projVersionParam) $(commonVersionParam) msal:publishMsalPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(commonVersionParam)
+          tasks: msal:assembleDistRelease $(projVersionParam) $(commonVersionParam)
+                 msal:publishMsalPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(commonVersionParam)
+                 msal:dependencies $(androidProjectDependencyParam)
 - stage: 'publishAdal'
   displayName: Adal - Build and publish
   dependsOn: publishCommonLibraries
@@ -143,5 +156,7 @@ stages:
           ENV_VSTS_MVN_ANDROIDADAL_USERNAME: $(mvnUserName)
           ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN: $(mvnAccessToken)
         inputs:
-          tasks: adal:assembleDist $(projVersionParam) $(commonVersionParam) adal:publishAdalPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(commonVersionParam)
+          tasks: adal:assembleDist $(projVersionParam) $(commonVersionParam)
+                 adal:publishAdalPublicationToVsts-maven-adal-androidRepository $(projVersionParam) $(commonVersionParam)
+                 adal:dependencies $(androidProjectDependencyParam)
 ...


### PR DESCRIPTION
### What
Enable Component Governance detection for android components via [gradle lockfile](https://docs.gradle.org/current/userguide/dependency_locking.html#generating_and_updating_dependency_locks)

### Why
Currently [Component Governance (CG)](https://aka.ms/cgbuildtaskdocs) runs as part of our pipelines but is not able to detect any components for our android specific pipelines and hence not able to report any vulnerability. 

### How
In order for CG task to detect components and report vulnerabilities it needs a gradle lockfile or a cgmanifet file which list down dependencies for our libraries. [Component Governance task ](https://docs.opensource.microsoft.com/tools/cg/features/buildtask/) can then scan the .lockfile and report any vulnerabilities for the dependencies listed in the lockfile.
In this PR I am updating our daily dev build pipeline to add gradle task to generate lockfile from the dependencies for each of our libraries.
e.g. `common4j:dependencies --configuration=runtimeClasspath --write-locks`

### Testing
Triggered a successful test run of the pipeline with CG task detecting components and reporting warnings for vulnerabilities
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=858049&view=results

### Other
Also updated the scheduled time for the pipeline run to 6:00AM UTC (10PM PST),  