### PR TITLE
Do not set buildDir in android-complete and java-complete build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,9 @@ buildscript {
 }
 
 allprojects {
-    if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
-        buildDir = "C:/temp/${rootProject.name}/${project.name}"
-    }
+//    if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+//        buildDir = "C:/temp/${rootProject.name}/${project.name}"
+//    }
 
     repositories {
         mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,6 @@ buildscript {
 }
 
 allprojects {
-//    if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
-//        buildDir = "C:/temp/${rootProject.name}/${project.name}"
-//    }
-
     repositories {
         mavenLocal()
         google()

--- a/java-complete/build.gradle
+++ b/java-complete/build.gradle
@@ -5,10 +5,6 @@ buildscript {
 }
 
 allprojects {
-    if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
-        buildDir = "C:/temp/${rootProject.name}/${project.name}"
-    }
-
     repositories {
         mavenLocal()
         google()


### PR DESCRIPTION
The default location for the build folder is projectDir/build. Originally, we were building everything to C:/temp because of windows long path restrictions, but those can now be addressed with registry settings.