### PR TITLE
Adding YubiKit Version to versions.gradle

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -60,6 +60,7 @@ ext {
     bouncyCastleVersion = "1.67"
     oshiCoreVersion = "5.7.5"
     tokenShare = "1.6.1"
+    yubikitAndroidVersion = "2.0.0"
 
     // TODO: adal automation test app.
     supportLibraryVersion = "27.1.+"


### PR DESCRIPTION
## Related PRs
-  Main PR in Common: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1729
- `keyboard` config changes in Broker Manifest: https://github.com/AzureAD/ad-accounts-for-android/pull/1869
- `keyboard` config changes in MSAL Manifest: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1618

## Summary
Adding a variable for YubiKit versioning. This may change somewhat soon, depending if YubiKit can/will release a new Maven build with updates. 
Please see the [main PR in Common](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1729) for a full description of changes being made to add YubiKit as a dependency.