### PR TITLE
Add Microsoft-identity-diagnostics continuous delivery pipeline

### DIFF
--- a/azure-pipelines/test-app/microsoft-identity-diagnostics-cd.yml
+++ b/azure-pipelines/test-app/microsoft-identity-diagnostics-cd.yml
@@ -1,0 +1,71 @@
+# File: azure-pipelines\test-app\microsoft-identity-diagnostics-cd.yml
+# Description: Build Deb and also publish the Deb as pipeline artifact.
+# Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME' was defined in the Variables tab
+# Variable: 'ENV_VSTS_MVN_OFFICE_ACCESSTOKEN' was defined in the Variables tab
+# Variable: 'mvnAccessToken' was defined in the Variables tab
+# Variable: 'vstsOfficeMavenAccessToken' was defined in the Variables tab
+# https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
+
+name: $(Build.BuildId)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+
+trigger: none
+pr: none
+
+schedules:
+  - cron: 0 3 * * *
+    branches:
+      include:
+        - master
+    always: true
+
+resources:
+  repositories:
+    - repository: broker
+      type: github
+      name: AzureAD/ad-accounts-for-android
+      ref: $(local_ad_accounts_branch)
+      endpoint: ANDROID_GITHUB
+
+jobs:
+  - job: build_deb
+    displayName: Build & Publish Deb for microsoft-identity-diagnostics-app
+    cancelTimeoutInMinutes: 1
+    pool:
+      vmImage: ubuntu-20.04
+    steps:
+      - checkout: broker
+        clean: true
+        submodules: recursive
+        persistCredentials: True
+      - task: CmdLine@1
+        displayName: Set MVN Access Token in Environment
+        inputs:
+          filename: echo
+          arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(mvnAccessToken)'
+      - task: CmdLine@1
+        displayName: Set Office MVN Access Token in Environment
+        inputs:
+          filename: echo
+          arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_OFFICE_ACCESSTOKEN]$(vstsOfficeMavenAccessToken)'
+      - task: Gradle@1
+        name: Gradle1
+        displayName: Build Deb with Java Dependency
+        inputs:
+          cwd: $(Build.SourcesDirectory)/broker-java-root
+          tasks: microsoft-identity-diagnostics:clean microsoft-identity-diagnostics:buildDeb --build-cache --info
+          publishJUnitResults: false
+          jdkArchitecture: x86
+          sqAnalysisBreakBuildIfQualityGateFailed: false
+      - task: CopyFiles@2
+        name: CopyFiles1
+        displayName: Copy Files to Artifact Staging Directory
+        inputs:
+          SourceFolder: microsoft-identity-diagnostics/build/distributions
+          TargetFolder: $(build.artifactstagingdirectory)
+      - task: PublishPipelineArtifact@1
+        name: PublishPipelineArtifacts1
+        displayName: 'Publish Artifact: microsoft-identity-diagnostics App Deb'
+        inputs:
+          ArtifactName: microsoft-identity-diagnostics Deb Package
+          TargetPath: $(build.artifactstagingdirectory)
+...


### PR DESCRIPTION
Added a CD pipeline for the Microsoft Identity Diagnostics component 

Link: https://identitydivision.visualstudio.com/Engineering/_build?definitionId=1703&_a=summary

The pipeline is in a position to:
 - Build and assemble the deb file.
 - Publish the deb file as a pipeline artifact retrievable by the packages.microsoft.com publishing pipeline.