### PR TITLE
Improves in the daily release pipeline

### DIFF
--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -6,15 +6,11 @@ parameters:
 - name: project
 - name: assembleCmd
   default: assemble
-- name: testCmd
-  default: test
 - name: publishCmd
   default: publish
 - name: dependencyParams
   default: ''
 - name: assembleParams
-  default: ''
-- name: testParams
   default: ''
 - name: publishParams
   default: ''
@@ -42,13 +38,6 @@ jobs:
     displayName: Build ${{ parameters.project }}
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.assembleParams}}
-    env:
-      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
-      ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
-  - task: Gradle@3
-    displayName: Test ${{ parameters.project }}
-    inputs:
-      tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.testParams}}
     env:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -6,11 +6,15 @@ parameters:
 - name: project
 - name: assembleCmd
   default: assemble
+- name: testCmd
+  default: test
 - name: publishCmd
   default: publish
 - name: dependencyParams
   default: ''
 - name: assembleParams
+  default: ''
+- name: testParams
   default: ''
 - name: publishParams
   default: ''
@@ -38,6 +42,13 @@ jobs:
     displayName: Build ${{ parameters.project }}
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.assembleParams}}
+    env:
+      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
+      ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
+  - task: Gradle@3
+    displayName: Test ${{ parameters.project }}
+    inputs:
+      tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.testParams}}
     env:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -35,10 +35,16 @@ jobs:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
   - task: Gradle@3
-    displayName: Build and Publish ${{ parameters.project }}
+    displayName: Build ${{ parameters.project }}
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.assembleParams}}
-             ${{ parameters.project }}:${{ parameters.publishCmd}} ${{ parameters.publishParams}}
+    env:
+      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
+      ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
+  - task: Gradle@3
+    displayName: Publish ${{ parameters.project }}
+    inputs:
+      tasks: ${{ parameters.project }}:${{ parameters.publishCmd}} ${{ parameters.publishParams}}
     env:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -41,8 +41,12 @@ resources:
       endpoint: ANDROID_GITHUB
 
 variables:
-  versionNumber: $(Build.BuildNumber)
+  ${{ if eq(variables['customVersionNumber'], '') }}:  
+    versionNumber: $(Build.BuildNumber)
+  ${{ else }}:
+    versionNumber: $(customVersionNumber)
   projVersionParam: -PprojVersion=$(versionNumber)
+  labApiUtilitiesVersionParam: -PdistLabApiUtilitiesVersion=$(versionNumber)
   common4jVersionParam: -PdistCommon4jVersion=$(versionNumber)
   broker4jVersionParam: -PdistBroker4jVersion=$(versionNumber)
   commonVersionParam: -PdistCommonVersion=$(versionNumber)
@@ -51,6 +55,19 @@ variables:
   javaProjectDependencyParam: --configuration=runtimeClasspath --write-locks
 
 stages:
+# :LabApiUtilities - Build and publish
+- stage: 'publishLabApiUtilitiesLibraries'
+  displayName: LabApiUtilities - Build and publish
+  jobs:
+  - template: assemble&publish.yml
+    parameters:
+      repository: common
+      project: LabApiUtilities
+      dependencyParams: $(javaProjectDependencyParam)
+      assembleParams: $(projVersionParam)
+      publishParams: $(projVersionParam)
+      vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
+      vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
 # Common4j - Build and publish
 - stage: 'publishCommon4jLibraries'
   displayName: Common4j - Build and publish
@@ -83,7 +100,9 @@ stages:
 # Broker4j - Build and publish
 - stage: 'publishBroke4jLibraries'
   displayName: Broker4j - Build and publish
-  dependsOn: publishCommon4jLibraries
+  dependsOn: 
+  - publishLabApiUtilitiesLibraries
+  - publishCommon4jLibraries
   jobs:
   - template: assemble&publish.yml
     parameters:
@@ -91,14 +110,16 @@ stages:
       project: broker4j
       publishCmd: publishAarPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(common4jVersionParam) $(javaProjectDependencyParam)
-      assembleParams: $(projVersionParam) $(common4jVersionParam)
-      publishParams: $(projVersionParam) $(common4jVersionParam)
+      assembleParams: $(projVersionParam) $(common4jVersionParam) $(labApiUtilitiesVersionParam)
+      publishParams: $(projVersionParam) $(common4jVersionParam) $(labApiUtilitiesVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
 # Broker - Build and publish
 - stage: 'publishBrokeLibraries'
   displayName: Broker - Build and publish
-  dependsOn: publishCommonLibraries
+  dependsOn: 
+  - publishCommonLibraries
+  - publishBroke4jLibraries
   jobs:
   - template: assemble&publish.yml
     parameters:

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -134,7 +134,7 @@ stages:
       project: AADAuthenticator
       assembleCmd: assembleDist
       publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
-      dependencyParams: $(androidProjectDependencyParam)
+      dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
       publishParams: $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
@@ -200,7 +200,7 @@ stages:
       project: msal
       assembleCmd: assembleDistRelease
       publishCmd: publishMsalPublicationToVsts-maven-adal-androidRepository 
-      dependencyParams: $(androidProjectDependencyParam)
+      dependencyParams: $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(commonVersionParam)
       publishParams: $(projVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROID_MSAL_USERNAME
@@ -216,7 +216,7 @@ stages:
       project: adal
       assembleCmd: assembleDist
       publishCmd: publishAdalPublicationToVsts-maven-adal-androidRepository 
-      dependencyParams: $(androidProjectDependencyParam)
+      dependencyParams: $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(commonVersionParam)
       publishParams: $(projVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADAL_USERNAME

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -71,6 +71,7 @@ stages:
       project: LabApiUtilities
       dependencyParams: $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam)
+      testParams: $(projVersionParam)
       publishParams: $(projVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
@@ -85,6 +86,7 @@ stages:
       project: common4j
       dependencyParams: $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam)
+      testParams: $(projVersionParam)
       publishParams: $(projVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
@@ -98,9 +100,11 @@ stages:
       repository: common
       project: common
       assembleCmd: assembleDist
+      testCmd: testDist
       publishCmd: publishDistReleasePublicationToVsts-maven-adal-androidRepository
       dependencyParams:  $(common4jVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam)
+      testParams: $(projVersionParam) $(common4jVersionParam)
       publishParams: $(projVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
@@ -118,6 +122,7 @@ stages:
       publishCmd: publishAarPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(common4jVersionParam) $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam) $(labApiUtilitiesVersionParam)
+      testParams: $(projVersionParam) $(common4jVersionParam) $(labApiUtilitiesVersionParam)
       publishParams: $(projVersionParam) $(common4jVersionParam) $(labApiUtilitiesVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
@@ -133,9 +138,11 @@ stages:
       repository: broker
       project: AADAuthenticator
       assembleCmd: assembleDist
+      testCmd: assembleDist
       publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
+      testParams: $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
       publishParams: $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
@@ -153,6 +160,7 @@ stages:
       publishCmd: publishAarPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(common4jVersionParam) $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
+      testParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
       publishParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
@@ -199,9 +207,11 @@ stages:
       repository: msal
       project: msal
       assembleCmd: assembleDistRelease
+      testCmd: testDistRelease
       publishCmd: publishMsalPublicationToVsts-maven-adal-androidRepository 
       dependencyParams: $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(commonVersionParam)
+      testParams: $(projVersionParam) $(commonVersionParam)
       publishParams: $(projVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROID_MSAL_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN
@@ -215,9 +225,11 @@ stages:
       repository: adal
       project: adal
       assembleCmd: assembleDist
+      testCmd: testDist
       publishCmd: publishAdalPublicationToVsts-maven-adal-androidRepository 
       dependencyParams: $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(commonVersionParam)
+      testParams: $(projVersionParam) $(commonVersionParam)
       publishParams: $(projVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADAL_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -71,6 +71,7 @@ stages:
 # Common4j - Build and publish
 - stage: 'publishCommon4jLibraries'
   displayName: Common4j - Build and publish
+  dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
   jobs:
   - template: assemble&publish.yml
     parameters:

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -99,7 +99,7 @@ stages:
       project: common
       assembleCmd: assembleDist
       publishCmd: publishDistReleasePublicationToVsts-maven-adal-androidRepository
-      dependencyParams: $(androidProjectDependencyParam)
+      dependencyParams:  $(common4jVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam)
       publishParams: $(projVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -41,7 +41,7 @@ resources:
       endpoint: ANDROID_GITHUB
 
 variables:
-  ${{ if eq(variables['customVersionNumber'], '') }}:  
+  ${{ if eq(variables.customVersionNumber, '') }}:  
     versionNumber: $(Build.BuildNumber)
   ${{ else }}:
     versionNumber: $(customVersionNumber)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -40,11 +40,17 @@ resources:
       ref: $(adalBranch)
       endpoint: ANDROID_GITHUB
 
+parameters:
+  - name: customVersionNumber
+    displayName: Version Number
+    type: string
+    default: Default
+
 variables:
-  ${{ if eq(variables.customVersionNumber, '') }}:  
+  ${{ if eq(parameters.customVersionNumber, 'Default') }}:  
     versionNumber: $(Build.BuildNumber)
   ${{ else }}:
-    versionNumber: $(customVersionNumber)
+    versionNumber:  ${{ parameters.customVersionNumber }}
   projVersionParam: -PprojVersion=$(versionNumber)
   labApiUtilitiesVersionParam: -PdistLabApiUtilitiesVersion=$(versionNumber)
   common4jVersionParam: -PdistCommon4jVersion=$(versionNumber)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -71,7 +71,6 @@ stages:
       project: LabApiUtilities
       dependencyParams: $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam)
-      testParams: $(projVersionParam)
       publishParams: $(projVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
@@ -86,7 +85,6 @@ stages:
       project: common4j
       dependencyParams: $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam)
-      testParams: $(projVersionParam)
       publishParams: $(projVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
@@ -100,11 +98,9 @@ stages:
       repository: common
       project: common
       assembleCmd: assembleDist
-      testCmd: testDist
       publishCmd: publishDistReleasePublicationToVsts-maven-adal-androidRepository
       dependencyParams:  $(common4jVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam)
-      testParams: $(projVersionParam) $(common4jVersionParam)
       publishParams: $(projVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
@@ -122,7 +118,6 @@ stages:
       publishCmd: publishAarPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(common4jVersionParam) $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam) $(labApiUtilitiesVersionParam)
-      testParams: $(projVersionParam) $(common4jVersionParam) $(labApiUtilitiesVersionParam)
       publishParams: $(projVersionParam) $(common4jVersionParam) $(labApiUtilitiesVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
@@ -138,11 +133,9 @@ stages:
       repository: broker
       project: AADAuthenticator
       assembleCmd: assembleDist
-      testCmd: assembleDist
       publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
-      testParams: $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
       publishParams: $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
@@ -160,7 +153,6 @@ stages:
       publishCmd: publishAarPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(common4jVersionParam) $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
-      testParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
       publishParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
@@ -207,11 +199,9 @@ stages:
       repository: msal
       project: msal
       assembleCmd: assembleDistRelease
-      testCmd: testDistRelease
       publishCmd: publishMsalPublicationToVsts-maven-adal-androidRepository 
       dependencyParams: $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(commonVersionParam)
-      testParams: $(projVersionParam) $(commonVersionParam)
       publishParams: $(projVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROID_MSAL_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN
@@ -225,11 +215,9 @@ stages:
       repository: adal
       project: adal
       assembleCmd: assembleDist
-      testCmd: testDist
       publishCmd: publishAdalPublicationToVsts-maven-adal-androidRepository 
       dependencyParams: $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(commonVersionParam)
-      testParams: $(projVersionParam) $(commonVersionParam)
       publishParams: $(projVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADAL_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -123,7 +123,7 @@ stages:
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
 # Broker - Build and publish
 - stage: 'publishBrokeLibraries'
-  displayName: Broker - Build and publish
+  displayName: Android Broker - Build and publish
   dependsOn: 
   - publishCommonLibraries
   - publishBroke4jLibraries

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -22,22 +22,22 @@ resources:
     - repository: common
       type: github
       name: AzureAD/microsoft-authentication-library-common-for-android
-      ref: $(commonBranch)
+      ref: dev
       endpoint: ANDROID_GITHUB
     - repository: broker
       type: github
       name: AzureAD/ad-accounts-for-android
-      ref: $(brokerBranch)
+      ref: dev
       endpoint: ANDROID_GITHUB
     - repository: msal
       type: github
       name: AzureAD/microsoft-authentication-library-for-android
-      ref: $(msalBranch)
+      ref: dev
       endpoint: ANDROID_GITHUB
     - repository: adal
       type: github
       name: AzureAD/azure-activedirectory-library-for-android
-      ref: $(adalBranch)
+      ref: dev
       endpoint: ANDROID_GITHUB
 
 parameters:


### PR DESCRIPTION
* Separate Build and publish, (it is easier to debug)
* Add custom version name to generate easy and fast builds on demand.
* add LabApiUtilities
 
Related https://github.com/AzureAD/ad-accounts-for-android/pull/1911