### PR TITLE
Use one maven access token through all the test app pipelines.

### DIFF
--- a/azure-pipelines/test-app/adal-test-app.yml
+++ b/azure-pipelines/test-app/adal-test-app.yml
@@ -2,10 +2,8 @@
 # Description: Build ADAL test app APK
 # use local_<project>_branch variables to build the Local version
 # use dist_<project>_version variables to build the Dist version
-# Variable 'local_[adal, common]_branch' was defined in the Variables tab
 # Variable 'dist_[adal, common]_version' was defined in the Variables tab
 # Variable: 'ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN' was defined in the Variables tab
-# Variable: 'mvnAccessToken' was defined in the Variables tab
 # https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
 name: $(Build.BuildId)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
@@ -86,7 +84,7 @@ jobs:
     displayName: Set MVN AccessToken in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN]$(mvnAccessToken)'
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN]$(AndroidAuthClient-Internal-Maven-Access-Token)'
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble adalTestApp

--- a/azure-pipelines/test-app/adal-test-app.yml
+++ b/azure-pipelines/test-app/adal-test-app.yml
@@ -40,12 +40,12 @@ resources:
   - repository: common
     type: github
     name: AzureAD/microsoft-authentication-library-common-for-android
-    ref: $(local_common_branch)
+    ref: dev
     endpoint: ANDROID_GITHUB
   - repository: adal
     type: github
     name: AzureAD/azure-activedirectory-library-for-android
-    ref: $(local_adal_branch)
+    ref: dev
     endpoint: ANDROID_GITHUB
 
 jobs:
@@ -53,6 +53,8 @@ jobs:
   displayName: Build ADAL Test App ${{ parameters.productFlavors }} ${{ parameters.signingConfigurations }} APK
   pool:
     vmImage: 'windows-latest'
+  variables:
+  - group: AndroidAuthClientVariables
   steps:
   - checkout: self
     clean: true

--- a/azure-pipelines/test-app/azure-sample-app.yml
+++ b/azure-pipelines/test-app/azure-sample-app.yml
@@ -5,7 +5,6 @@
 # Variable 'local_[msal, azuresample]_branch' was defined in the Variables tab
 # Variable 'dist_[msal, azuresample]_version' was defined in the Variables tab
 # Variable: 'ENV_VSTS_MVN_ANDROID_MSAL_USERNAME' was defined in the Variables tab
-# Variable: 'mvnAccessToken' was defined in the Variables tab
 # https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
 name: $(Build.BuildId)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
@@ -40,17 +39,17 @@ resources:
   - repository: msal
     type: github
     name: AzureAD/microsoft-authentication-library-for-android
-    ref: $(local_msal_branch)
+    ref: dev
     endpoint: ANDROID_GITHUB
   - repository: azuresample
     type: github
     name: Azure-Samples/ms-identity-android-java
-    ref: $(local_azuresample_branch)
+    ref: master
     endpoint: ANDROID_GITHUB
   - repository: common
     type: github
     name: AzureAD/microsoft-authentication-library-common-for-android
-    ref: $(local_common_branch)
+    ref: dev
     endpoint: ANDROID_GITHUB
 
 jobs:
@@ -58,6 +57,8 @@ jobs:
   displayName: Build Azure Samples ${{ parameters.productFlavors }} ${{ parameters.signingConfigurations }} APK
   pool:
     vmImage: 'windows-latest'
+  variables:
+  - group: AndroidAuthClientVariables
   steps:
   - checkout: self
     clean: true
@@ -89,7 +90,7 @@ jobs:
     displayName: Set MVN AccessToken in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(mvnAccessToken)'
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClient-Internal-Maven-Access-Token)'
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble Azure Sample

--- a/azure-pipelines/test-app/broker-host.yml
+++ b/azure-pipelines/test-app/broker-host.yml
@@ -40,22 +40,22 @@ resources:
   - repository: common
     type: github
     name: AzureAD/microsoft-authentication-library-common-for-android
-    ref: $(local_common_branch)
+    ref: dev
     endpoint: ANDROID_GITHUB
   - repository: msal
     type: github
     name: AzureAD/microsoft-authentication-library-for-android
-    ref: $(local_msal_branch)
+    ref: dev
     endpoint: ANDROID_GITHUB
   - repository: adal
     type: github
     name: AzureAD/azure-activedirectory-library-for-android
-    ref: $(local_adal_branch)
+    ref: dev
     endpoint: ANDROID_GITHUB
   - repository: broker
     type: github
     name: AzureAD/ad-accounts-for-android
-    ref: $(local_ad_accounts_branch)
+    ref: dev
     endpoint: ANDROID_GITHUB
 
 jobs:
@@ -63,6 +63,8 @@ jobs:
   displayName: Build BrokerHost ${{ parameters.productFlavors }} ${{ parameters.signingConfigurations }} APK
   pool:
     vmImage: 'windows-latest'
+  variables:
+  - group: AndroidAuthClientVariables
   steps:
   - checkout: self
     clean: true
@@ -109,7 +111,7 @@ jobs:
     displayName: Set MVN AccessToken in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(mvnAccessToken)'
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClient-Internal-Maven-Access-Token)'
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble BrokerHost

--- a/azure-pipelines/test-app/broker-host.yml
+++ b/azure-pipelines/test-app/broker-host.yml
@@ -2,10 +2,8 @@
 # Description: Generate BrokerHost APK
 # use local_<project>_branch variables to build the Local version
 # use dist_<project>_version variables to build the Dist version
-# Variable 'local_[adal, common, msal, ad_accounts]_branch' was defined in the Variables tab
 # Variable 'dist_[adal, common, msal, ad_accounts]_version' was defined in the Variables tab
 # Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN' was defined in the Variables tab
-# Variable: 'mvnAccessToken' was defined in the Variables tab
 # https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
 name: $(Build.BuildId)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 

--- a/azure-pipelines/test-app/java-linux-test-app.yml
+++ b/azure-pipelines/test-app/java-linux-test-app.yml
@@ -1,7 +1,6 @@
 # File: azure-pipelines\test-app\java-linux-test-app.yml
 # Description: Buil Deb and also publish the Deb as pipeline artifact.
 # Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME' was defined in the Variables tab
-# Variable: 'mvnAccessToken' was defined in the Variables tab
 # https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
 
 name: $(Build.BuildId)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
@@ -21,7 +20,7 @@ resources:
   - repository: broker
     type: github
     name: AzureAD/ad-accounts-for-android
-    ref: $(local_ad_accounts_branch)
+    ref: dev
     endpoint: ANDROID_GITHUB
 
 jobs:
@@ -30,6 +29,8 @@ jobs:
   cancelTimeoutInMinutes: 1
   pool:
     vmImage: ubuntu-20.04
+  variables:
+  - group: AndroidAuthClientVariables
   steps:
   - checkout: broker
     clean: true
@@ -39,7 +40,7 @@ jobs:
     displayName: Set MVN Access Token in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(mvnAccessToken)'
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClient-Internal-Maven-Access-Token)'
   - task: Gradle@1
     name: Gradle1
     displayName: Build Deb with Java Dependency

--- a/azure-pipelines/test-app/microsoft-identity-diagnostics-cd.yml
+++ b/azure-pipelines/test-app/microsoft-identity-diagnostics-cd.yml
@@ -2,8 +2,6 @@
 # Description: Build Deb and also publish the Deb as pipeline artifact.
 # Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME' was defined in the Variables tab
 # Variable: 'ENV_VSTS_MVN_OFFICE_ACCESSTOKEN' was defined in the Variables tab
-# Variable: 'mvnAccessToken' was defined in the Variables tab
-# Variable: 'vstsOfficeMavenAccessToken' was defined in the Variables tab
 # https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
 
 name: $(Build.BuildId)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
@@ -32,6 +30,8 @@ jobs:
     cancelTimeoutInMinutes: 1
     pool:
       vmImage: ubuntu-20.04
+    variables:
+    - group: AndroidAuthClientVariables
     steps:
       - checkout: broker
         clean: true
@@ -41,12 +41,12 @@ jobs:
         displayName: Set MVN Access Token in Environment
         inputs:
           filename: echo
-          arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(mvnAccessToken)'
+          arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClient-Internal-Maven-Access-Token)'
       - task: CmdLine@1
         displayName: Set Office MVN Access Token in Environment
         inputs:
           filename: echo
-          arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_OFFICE_ACCESSTOKEN]$(vstsOfficeMavenAccessToken)'
+          arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_OFFICE_ACCESSTOKEN]$(AndroidAuthClient-Office-Maven-Access-Token)'
       - task: Gradle@1
         name: Gradle1
         displayName: Build Deb with Java Dependency

--- a/azure-pipelines/test-app/msal-test-app.yml
+++ b/azure-pipelines/test-app/msal-test-app.yml
@@ -3,7 +3,6 @@
 # Variable 'local_msal_branch' was defined in the Variables tab
 # Variable 'msal_version' was defined in the Variables tab
 # Variable: 'ENV_VSTS_MVN_ANDROIDMSAL_ACCESSTOKEN' was defined in the Variables tab
-# Variable: 'mvnAccessToken' was defined in the Variables tab
 # https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
 name: $(Build.BuildId)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
@@ -38,12 +37,12 @@ resources:
   - repository: common
     type: github
     name: AzureAD/microsoft-authentication-library-common-for-android
-    ref: $(local_common_branch)
+    ref: dev
     endpoint: ANDROID_GITHUB
   - repository: msal
     type: github
     name: AzureAD/microsoft-authentication-library-for-android
-    ref: $(local_msal_branch)
+    ref: dev
     endpoint: ANDROID_GITHUB
 
 jobs:
@@ -51,6 +50,8 @@ jobs:
   displayName: Build MSAL Test App ${{ parameters.productFlavors }} ${{ parameters.signingConfigurations }} ${{variables.msal_version}} APK
   pool:
     vmImage: 'windows-latest'
+  variables:
+  - group: AndroidAuthClientVariables
   steps:
   - checkout: self
     clean: true
@@ -79,7 +80,7 @@ jobs:
     displayName: Set MVN AccessToken in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_USERNAME]$(mvnAccessToken)'
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_USERNAME]$(AndroidAuthClient-Internal-Maven-Access-Token)'
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble msalTestApp


### PR DESCRIPTION
This is part of an effort to remove all the copies of maven access token in each pipeline and have just one token, so we don't have to update multiple pipelines.

Library to store VSTS access tokens: 
https://identitydivision.visualstudio.com/Engineering/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=14&path=AndroidAuthClientVariables

Also remove variables in branches in favor to use resources tab.

### Results:
https://identitydivision.visualstudio.com/Engineering/_build?definitionScope=%5CAndroid%5CTesting%20and%20Automation%20Pipelines%5CTest%20Apps
