### PR TITLE
Adding Intune App SDK and supporting gradle plugin to android_auth ro…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,21 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            // msazure and aria are consumed via upstream sources of the AndroidADAL feed.
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            credentials {
+                username project.vstsUsername
+                password project.vstsMavenAccessToken
+            }
+        }
     }
 
     dependencies {
         classpath "com.android.tools.build:gradle:${rootProject.ext.gradleVersion}"
+        classpath "org.javassist:javassist:${rootProject.ext.javaAssistVersion}"
+        classpath "com.microsoft.intune.mam:android-build-plugin:${rootProject.ext.intuneAppSdkVersion}"
     //    classpath "net.serenity-bdd:serenity-gradle-plugin:1.9.6"
     //    classpath 'com.google.gms:google-services:3.2.1'
     //    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -61,6 +61,8 @@ ext {
     oshiCoreVersion = "5.7.5"
     tokenShare = "1.6.1"
     yubikitAndroidVersion = "2.0.0"
+    intuneAppSdkVersion = "8.6.3"
+    javaAssistVersion = "3.27.0-GA"
 
     // TODO: adal automation test app.
     supportLibraryVersion = "27.1.+"

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,15 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
+        maven {
+            // msazure and aria are consumed via upstream sources of the AndroidADAL feed.
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            credentials {
+                username vstsUsername
+                password vstsMavenAccessToken
+            }
+        }
     }
 }
 


### PR DESCRIPTION
In order to better Test MAM scenarios.  Adding the Intune App SDK and supporting build.gradle plugin to the root android_auth project.