### PR TITLE
enable auto-google-login on test devices

### DIFF
--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -229,6 +229,7 @@ stages:
             --type instrumentation \
             --app "$(Pipeline.Workspace)/msalautomationapks/$(msalApp)" \
             --test "$(Pipeline.Workspace)/msalautomationapks/$(msaltestApp)" \
+            --auto-google-login \
             --record-video \
             --device model=${{ parameters.firebaseDeviceId }},version=${{ parameters.firebaseDeviceAndroidVersion }},locale=en,orientation=portrait \
             --timeout "$(firebaseTimeout)" \
@@ -293,6 +294,7 @@ stages:
             --type instrumentation \
             --app "$(Pipeline.Workspace)/brokerautomationapks/$(brokerApp)" \
             --test "$(Pipeline.Workspace)/brokerautomationapks/$(brokertestApp)" \
+            --auto-google-login \
             --record-video \
             --device model=${{ parameters.firebaseDeviceId }},version=${{ parameters.firebaseDeviceAndroidVersion }},locale=en,orientation=portrait \
             --timeout "$(firebaseTimeout)" \


### PR DESCRIPTION
Quick PR to add the auto-google-login arguement to broker CI pipeline, allowing runner to login to a google account on the physical testing device to access play store and other features.