### PR TITLE
[WIP] Init vstsUsername & vstsMavenAccessToken

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,10 @@
  * Detailed information about configuring a multi-project build in Gradle can be found
  * in the user guide at https://docs.gradle.org/5.1.1/userguide/multi_project_builds.html
  */
+
+vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMPLETE_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMPLETE_USERNAME") : project.findProperty("vstsUsername")
+vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMPLETE_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMPLETE_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+
 pluginManagement {
     repositories {
         mavenLocal()
@@ -67,14 +71,14 @@ project(':uiautomationutilities').projectDir = new File('common/uiautomationutil
 include(":brokerautomationapp")
 project(':brokerautomationapp').projectDir = new File('broker/brokerautomationapp')
 
-include(":oneauth")
-project(':oneauth').projectDir = new File('oneauth/sources/android/gradle')
+//include(":oneauth")
+//project(':oneauth').projectDir = new File('oneauth/sources/android/gradle')
 
-include(":oneauthtestapp")
-project(':oneauthtestapp').projectDir = new File('oneauth/testapps/android/oneauthtestapp/app')
+//include(":oneauthtestapp")
+//project(':oneauthtestapp').projectDir = new File('oneauth/testapps/android/oneauthtestapp/app')
 
-include(":msalcpptesthost")
-project(':msalcpptesthost').projectDir = new File('msalcpp/test/android/testhost/app')
+//include(":msalcpptesthost")
+//project(':msalcpptesthost').projectDir = new File('msalcpp/test/android/testhost/app')
 
 // Pure Java DevX Projects
 include(':common4j')
@@ -112,7 +116,7 @@ project(':AzureSample').projectDir = new File('azuresample/app')
 
 
 // Authenticator projects
-
+//
 //include(":app")
 //project(':app').projectDir = new File('authenticator/PhoneFactor/app')
 //
@@ -160,4 +164,4 @@ project(':AzureSample').projectDir = new File('azuresample/app')
 //
 //include(":RootDetectionLibrary")
 //project(':RootDetectionLibrary').projectDir = new File('authenticator/PhoneFactor/RootDetectionLibrary')
-
+//

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,10 +6,6 @@
  * Detailed information about configuring a multi-project build in Gradle can be found
  * in the user guide at https://docs.gradle.org/5.1.1/userguide/multi_project_builds.html
  */
-
-vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMPLETE_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMPLETE_USERNAME") : project.findProperty("vstsUsername")
-vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMPLETE_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMPLETE_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
-
 pluginManagement {
     repositories {
         mavenLocal()
@@ -21,8 +17,12 @@ pluginManagement {
             name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
-                username vstsUsername
-                password vstsMavenAccessToken
+                username System.getenv("ENV_VSTS_MVN_ANDROIDCOMPLETE_USERNAME") != null ?
+                        System.getenv("ENV_VSTS_MVN_ANDROIDCOMPLETE_USERNAME") :
+                        project.findProperty("vstsUsername")
+                password System.getenv("ENV_VSTS_MVN_ANDROIDCOMPLETE_ACCESSTOKEN") != null ?
+                        System.getenv("ENV_VSTS_MVN_ANDROIDCOMPLETE_ACCESSTOKEN") :
+                        project.findProperty("vstsMavenAccessToken")
             }
         }
     }


### PR DESCRIPTION
Changes were made to the android-complete project to introduce a maven repository.

![image](https://user-images.githubusercontent.com/1685221/189801260-27e20f89-476f-4eaf-a63e-d1b8069730a9.png)
```
maven {
            // msazure and aria are consumed via upstream sources of the AndroidADAL feed.
            name "vsts-maven-adal-android"
            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
            credentials {
                username vstsUsername
                password vstsMavenAccessToken
            }
        }
```

Unfortunately, the username and password fields were not initialized in the pipeline.
I am adding two parameters i.e.,

 - ENV_VSTS_MVN_ANDROIDCOMPLETE_USERNAME
 - ENV_VSTS_MVN_ANDROIDCOMPLETE_ACCESSTOKEN

that will be used to help init the pipeline variables.

Broken pipelines:
https://identitydivision.visualstudio.com/Engineering/_build?definitionScope=%5CAndroid%5CTesting%20and%20Automation%20Pipelines%5CTest%20Apps
