### PR TITLE
Fix failing test-app pipelines.

### DIFF
--- a/azure-pipelines/test-app/adal-test-app.yml
+++ b/azure-pipelines/test-app/adal-test-app.yml
@@ -84,7 +84,7 @@ jobs:
     displayName: Set MVN AccessToken in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClient-Internal-Maven-Access-Token)'
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClientInternalMavenAccessToken)'
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble adalTestApp

--- a/azure-pipelines/test-app/adal-test-app.yml
+++ b/azure-pipelines/test-app/adal-test-app.yml
@@ -84,7 +84,7 @@ jobs:
     displayName: Set MVN AccessToken in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN]$(AndroidAuthClient-Internal-Maven-Access-Token)'
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClient-Internal-Maven-Access-Token)'
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble adalTestApp

--- a/azure-pipelines/test-app/azure-sample-app.yml
+++ b/azure-pipelines/test-app/azure-sample-app.yml
@@ -90,7 +90,7 @@ jobs:
     displayName: Set MVN AccessToken in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClient-Internal-Maven-Access-Token)'
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClientInternalMavenAccessToken)'
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble Azure Sample

--- a/azure-pipelines/test-app/broker-host.yml
+++ b/azure-pipelines/test-app/broker-host.yml
@@ -109,7 +109,7 @@ jobs:
     displayName: Set MVN AccessToken in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClient-Internal-Maven-Access-Token)'
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClientInternalMavenAccessToken)'
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble BrokerHost

--- a/azure-pipelines/test-app/java-linux-test-app.yml
+++ b/azure-pipelines/test-app/java-linux-test-app.yml
@@ -40,7 +40,7 @@ jobs:
     displayName: Set MVN Access Token in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClient-Internal-Maven-Access-Token)'
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClientInternalMavenAccessToken)'
   - task: Gradle@1
     name: Gradle1
     displayName: Build Deb with Java Dependency

--- a/azure-pipelines/test-app/microsoft-identity-diagnostics-cd.yml
+++ b/azure-pipelines/test-app/microsoft-identity-diagnostics-cd.yml
@@ -41,7 +41,7 @@ jobs:
         displayName: Set MVN Access Token in Environment
         inputs:
           filename: echo
-          arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClient-Internal-Maven-Access-Token)'
+          arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClientInternalMavenAccessToken)'
       - task: CmdLine@1
         displayName: Set Office MVN Access Token in Environment
         inputs:

--- a/azure-pipelines/test-app/msal-test-app.yml
+++ b/azure-pipelines/test-app/msal-test-app.yml
@@ -80,7 +80,7 @@ jobs:
     displayName: Set MVN AccessToken in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClient-Internal-Maven-Access-Token)'
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClientInternalMavenAccessToken)'
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble msalTestApp

--- a/azure-pipelines/test-app/msal-test-app.yml
+++ b/azure-pipelines/test-app/msal-test-app.yml
@@ -80,7 +80,7 @@ jobs:
     displayName: Set MVN AccessToken in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_USERNAME]$(AndroidAuthClient-Internal-Maven-Access-Token)'
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(AndroidAuthClient-Internal-Maven-Access-Token)'
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble msalTestApp

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,8 @@ buildscript {
             name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
-                username project.vstsUsername
-                password project.vstsMavenAccessToken
+                username System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME")
+                password System.getenv("ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN")
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,8 +17,8 @@ pluginManagement {
             name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
-                username vstsUsername
-                password vstsMavenAccessToken
+                username System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME")
+                password System.getenv("ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN")
             }
         }
     }


### PR DESCRIPTION
The TestApp pipelines are failing https://identitydivision.visualstudio.com/Engineering/_build?definitionScope=%5CAndroid%5CTesting%20and%20Automation%20Pipelines%5CTest%20Apps 

This was a result of this change: https://github.com/AzureAD/android-complete/pull/148/files

We need to read the vstsUsername and vstsAccessToken directly from the environment in both `build.gradle` and `settings.gradle`

