### PR TITLE
Revert Azure Sample APK Name Change

### DIFF
--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -30,7 +30,7 @@ variables:
   msalTestApp: msalautomationapp-dist-AutoBroker-debug-androidTest.apk
   brokerApp: brokerautomationapp-dist-AutoBroker-debug.apk
   brokerTestApp: brokerautomationapp-dist-AutoBroker-debug-androidTest.apk
-  azureSampleApk: AzureSample-external-release.apk
+  azureSampleApk: AzureSample-local-debug.apk
   companyPortalApk: com.microsoft.windowsintune.companyportal-signed.apk
   authenticatorApk: app-production-universal-release-signed.apk
   oldAuthenticatorApk: app-production-universal-release-signed.apk


### PR DESCRIPTION
Test app pipelines were recently fixed, which caused the azure sample apk name to return to `AzureSample-local-debug.apk`. For a while it was `AzureSample-external-release.apk` due to a band-aid fix we did to get test app pipelines temporarily working.