### PR TITLE
Remove brokerautomationapp API 29- Stage from Broker CI Pipeline (No Tests)

### DIFF
--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -138,7 +138,7 @@ stages:
   dependsOn:
   - msalautomationapp
   - brokers_azure_sample
-  displayName: Running MSAL with Broker Test Plan (API 30+)
+  displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceIdHigh }})
   jobs:
     - template: ./templates/flank/run-on-firebase-with-flank.yml
       parameters:
@@ -154,15 +154,16 @@ stages:
                       /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
-        testRunTitle: "Broker(MSAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
+        testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceIdHigh }}) # $(Build.BuildNumber)"
         apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+        flankShards: ${{ parameters.flankShards }}
 # MSAL with Broker Test Plan stage (API 29-)
 - stage: 'msal_with_broker_low_api'
   dependsOn:
     - msalautomationapp
     - brokers_azure_sample
     - firstpartyapps
-  displayName: Running MSAL with Broker Test Plan (API 29-)
+  displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceIdLow }})
   jobs:
     - template: ./templates/run-on-firebase.yml
       parameters:
@@ -181,14 +182,14 @@ stages:
                       /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
-        testRunTitle: "Broker(MSAL) UI Automation - Build (API 29-) # $(Build.BuildNumber)"
+        testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceIdLow }}) # $(Build.BuildNumber)"
         apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
 # ADAL with Broker Test Plan stage (API 30+)
 - stage: 'adal_with_broker_high_api'
   dependsOn:
   - brokerautomationapp
   - brokers_azure_sample
-  displayName: ADAL with broker and Broker basic validation test plan (API 30+)
+  displayName: ADAL with broker and Broker basic validation test plan (API ${{ parameters.firebaseDeviceIdHigh }})
   jobs:
     - template: ./templates/flank/run-on-firebase-with-flank.yml
       parameters:
@@ -207,5 +208,6 @@ stages:
                       /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
-        testRunTitle: "Broker(ADAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
+        testRunTitle: "Broker(ADAL) UI Automation - Build (API ${{ parameters.firebaseDeviceIdHigh }}) # $(Build.BuildNumber)"
         apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+        flankShards: ${{ parameters.flankShards }}

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -1,7 +1,12 @@
 # run broker UI automation testcases
+# Variable: 'azure_sample_apk' was defined in the Variables tab
+# Variable: 'broker_branch' was defined in the Variables tab
+# Variable: 'brokerhost_apk' was defined in the Variables tab
 # Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME' was defined in the Variables tab
 # Variable: 'gCloudProjectId' was defined in the Variables tab
+# Variable: 'msal_branch' was defined in the Variables tab
 # Variable: 'mvnAccessToken' was defined in the Variables tab
+# https://dev.azure.com/IdentityDivision/Engineering/_build?definitionId=1490&_a=summary
 name: $(Build.BuildId)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
 trigger: none
@@ -142,8 +147,7 @@ stages:
                       /data/local/tmp/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
-                      /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
-                      /data/local/tmp/OldBrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhost_apk)"
+                      /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(MSAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
@@ -168,7 +172,6 @@ stages:
                       /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
-                      /data/local/tmp/OldBrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhost_apk),\
                       /data/local/tmp/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\
                       /data/local/tmp/Teams.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(teamsApk),\
                       /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk)"
@@ -195,36 +198,10 @@ stages:
                       /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
-                      /data/local/tmp/OldBrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhost_apk)"
+                      /data/local/tmp/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\
+                      /data/local/tmp/Teams.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(teamsApk),\
+                      /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(ADAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
         apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
-# ADAL with Broker Test Plan stage (API 29-)
-- stage: 'adal_with_broker_low_api'
-  dependsOn:
-    - brokerautomationapp
-    - brokers_azure_sample
-    - firstpartyapps
-  displayName: ADAL with broker and Broker basic validation test plan (API 29-)
-  jobs:
-    - template: ./templates/run-on-firebase.yml
-      parameters:
-        automationAppApkPath: "$(Pipeline.Workspace)/brokerautomationapks/$(brokerApp)"
-        automationAppTestApkPath: "$(Pipeline.Workspace)/brokerautomationapks/$(brokertestApp)"
-        testTargetPackages: ${{ parameters.brokerTestTarget }}
-        resultsHistoryName: "$(resultsHistoryName)"
-        resultsDir: "brokerautomationapp-testpass-adal&basic-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
-        otherFiles: "/data/local/tmp/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
-                      /data/local/tmp/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
-                      /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
-                      /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
-                      /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
-                      /data/local/tmp/OldBrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhost_apk),\
-                      /data/local/tmp/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\
-                      /data/local/tmp/Teams.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(teamsApk),\
-                      /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk)"
-        firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
-        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
-        testRunTitle: "Broker(ADAL) UI Automation - Build (API 29-) # $(Build.BuildNumber)"
-        apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -61,6 +61,10 @@ parameters:
   displayName: Firebase Device Android Version (Api 29-)
   type: number
   default: 28
+- name: flankShards
+  displayName: Max Number of Flank Shards
+  type: number
+  default: 2
 - name: authenticatorVersion
   displayName: Authenticator Version
   type: string

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -84,11 +84,11 @@ parameters:
 - name: msalTestTarget
   displayName: Test Targets for MSAL
   type: string
-  default: package com.microsoft.identity.client.msal.automationapp.testpass.broker, notAnnotation org.junit.Ignore, notAnnotation com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline
+  default: package com.microsoft.identity.client.msal.automationapp.testpass.broker, notAnnotation org.junit.Ignore, notAnnotation com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline, notAnnotation com.microsoft.identity.client.ui.automation.annotations.LongUIAutomationTest
 - name: brokerTestTarget
   displayName: Test Targets for Broker
   type: string
-  default: package com.microsoft.identity.client.broker.automationapp.testpass, notPackage com.microsoft.identity.client.broker.automationapp.testpass.local.adalonly, notAnnotation org.junit.Ignore, notAnnotation com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline
+  default: package com.microsoft.identity.client.broker.automationapp.testpass, notPackage com.microsoft.identity.client.broker.automationapp.testpass.local.adalonly, notAnnotation org.junit.Ignore, notAnnotation com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline, notAnnotation com.microsoft.identity.client.ui.automation.annotations.LongUIAutomationTest
 
 stages:
 # msalautomationapp

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -138,7 +138,7 @@ stages:
   dependsOn:
   - msalautomationapp
   - brokers_azure_sample
-  displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceIdHigh }})
+  displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
   jobs:
     - template: ./templates/flank/run-on-firebase-with-flank.yml
       parameters:
@@ -154,7 +154,7 @@ stages:
                       /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
-        testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceIdHigh }}) # $(Build.BuildNumber)"
+        testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"
         apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
         flankShards: ${{ parameters.flankShards }}
 # MSAL with Broker Test Plan stage (API 29-)
@@ -163,7 +163,7 @@ stages:
     - msalautomationapp
     - brokers_azure_sample
     - firstpartyapps
-  displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceIdLow }})
+  displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionLow }})
   jobs:
     - template: ./templates/run-on-firebase.yml
       parameters:
@@ -182,14 +182,14 @@ stages:
                       /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
-        testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceIdLow }}) # $(Build.BuildNumber)"
+        testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionLow }}) # $(Build.BuildNumber)"
         apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
 # ADAL with Broker Test Plan stage (API 30+)
 - stage: 'adal_with_broker_high_api'
   dependsOn:
   - brokerautomationapp
   - brokers_azure_sample
-  displayName: ADAL with broker and Broker basic validation test plan (API ${{ parameters.firebaseDeviceIdHigh }})
+  displayName: ADAL with broker and Broker basic validation test plan (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
   jobs:
     - template: ./templates/flank/run-on-firebase-with-flank.yml
       parameters:
@@ -208,6 +208,6 @@ stages:
                       /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
-        testRunTitle: "Broker(ADAL) UI Automation - Build (API ${{ parameters.firebaseDeviceIdHigh }}) # $(Build.BuildNumber)"
+        testRunTitle: "Broker(ADAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"
         apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
         flankShards: ${{ parameters.flankShards }}

--- a/azure-pipelines/ui-automation/templates/flank/flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/flank.yml
@@ -1,9 +1,4 @@
 flank:
-  ## Max Test Shards
-  # test shards - the amount of groups to split the test suite into
-  # set to -1 to use one shard per test. default: 1
-  max-test-shards: 2
-
   ## Number of Test Runs
   # test runs - the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           GOOGLE_APPLICATION_CREDENTIALS: $(gcServiceAccountKey.secureFilePath)
         name: runUiAutomation
-        displayName: Run UI Automation on Firebase
+        displayName: Run UI Automation on Firebase (with Flank)
         inputs:
           targetType: inline
           script: |
@@ -70,7 +70,7 @@ jobs:
               --environment-variables "clearPackageData=true" \
               --results-history-name "${{ parameters.resultsHistoryName }}" \
               --test-targets "${{ parameters.testTargetPackages }}, ${{ parameters.apiLevelTarget }}" \
-              --max-test-shards ${{ parameters.flankShards }}
+              --max-test-shards ${{ parameters.flankShards }} \
               --smart-flank-gcs-path "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/smart-flank-xml/broker-ci/JUnitReport.xml"
       - script: gsutil cp "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/${{ parameters.resultsDir }}/JUnitReport.xml" "$(Build.SourcesDirectory)"
         displayName: Download Test Result File

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -22,6 +22,8 @@ parameters:
     type: number
   - name: testRunTitle
     type: string
+  - name: flankShards
+    type: number
 
 jobs:
   - job: 'run_on_firebase'
@@ -68,6 +70,7 @@ jobs:
               --environment-variables "clearPackageData=true" \
               --results-history-name "${{ parameters.resultsHistoryName }}" \
               --test-targets "${{ parameters.testTargetPackages }}, ${{ parameters.apiLevelTarget }}" \
+              --max-test-shards ${{ parameters.flankShards }}
               --smart-flank-gcs-path "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/smart-flank-xml/broker-ci/JUnitReport.xml"
       - script: gsutil cp "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/${{ parameters.resultsDir }}/JUnitReport.xml" "$(Build.SourcesDirectory)"
         displayName: Download Test Result File


### PR DESCRIPTION
This PR is accompanied by a Broker PR that moves all First Party App UI test cases to run on api 30+, so there are no more tests that would be ran on API 29- as part of brokerautomationapp. Passing no tests to a stage in these pipelines will result in a failure, so deleting this stage entirely since there are no tests to pass to it.

Broker: https://github.com/AzureAD/ad-accounts-for-android/pull/2052