### PR TITLE
Download Edge from universal packages, extra stage to run brokerhost tests in broker CI

### DIFF
--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -141,6 +141,12 @@ stages:
   - brokers_azure_sample
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
   jobs:
+    - task: DownloadSecureFile@1
+        displayName: 'Download Certificate File'
+        name: certificateFile
+        inputs:
+          secureFile: mfatest.pfx
+          retryCount: 5
     - template: ./templates/flank/run-on-firebase-with-flank.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/$(msalApp)"
@@ -152,7 +158,8 @@ stages:
                       /data/local/tmp/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
-                      /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk)"
+                      /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
+                      /storage/self/primary/Download/mfatest.pfx=$(certificateFile.secureFilePath)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -172,9 +172,9 @@ stages:
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"
-        apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+        extraTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus, notAnnotation com.microsoft.identity.client.ui.automation.annotations.LocalBrokerHostDebugUiTest"
         flankShards: ${{ parameters.flankShards }}
-# MSAL with Broker Test Plan stage (API 30+)
+# MSAL with Broker Test Plan stage (BrokerHost Tests) (API 30+)
 - stage: 'msal_with_brokerhost_high_api'
   dependsOn:
     - msalautomationapplocalbrokerhost
@@ -186,7 +186,7 @@ stages:
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapksbrokerhost/$(msalAppLocalBrokerHost)"
         automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapksbrokerhost/$(msaltestAppLocalBrokerHost)"
-        testTargetPackages: "${{ parameters.msalTestTarget }}, annotation com.microsoft.identity.client.ui.automation.annotations.LocalBrokerHostDebugUiTest"
+        testTargetPackages: ${{ parameters.msalTestTarget }}
         resultsHistoryName: "$(resultsHistoryName)"
         resultsDir: "msalautomationapp-testpass-brokerhost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
         otherFiles: "/data/local/tmp/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
@@ -198,7 +198,7 @@ stages:
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(MSAL) UI Automation - Build (BrokerHost Tests) (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"
-        apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+        extraTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus, annotation com.microsoft.identity.client.ui.automation.annotations.LocalBrokerHostDebugUiTest"
 # MSAL with Broker Test Plan stage (API 29-)
 - stage: 'msal_with_broker_low_api'
   dependsOn:
@@ -226,7 +226,7 @@ stages:
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
         testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionLow }}) # $(Build.BuildNumber)"
-        apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+        extraTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
 # ADAL with Broker Test Plan stage (API 30+)
 - stage: 'adal_with_broker_high_api'
   dependsOn:
@@ -253,5 +253,5 @@ stages:
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(ADAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"
-        apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+        extraTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
         flankShards: ${{ parameters.flankShards }}

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -36,7 +36,7 @@ variables:
   brokerApp: brokerautomationapp-dist-AutoBroker-debug.apk
   brokerTestApp: brokerautomationapp-dist-AutoBroker-debug-androidTest.apk
   companyPortalApk: com.microsoft.windowsintune.companyportal-signed.apk
-  authenticatorApk: app-production-universal-release-signed-PROD.apk
+  authenticatorApk: app-production-universal-release-signed.apk
   oldAuthenticatorApk: Authenticator-4.1.0-RC.apk
   outlookApk: Outlook.apk
   teamsApk: Teams.apk

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -142,11 +142,11 @@ stages:
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
   jobs:
     - task: DownloadSecureFile@1
-        displayName: 'Download Certificate File'
-        name: certificateFile
-        inputs:
-          secureFile: mfatest.pfx
-          retryCount: 5
+      displayName: 'Download Certificate File'
+      name: certificateFile
+      inputs:
+        secureFile: mfatest.pfx
+        retryCount: 5
     - template: ./templates/flank/run-on-firebase-with-flank.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/$(msalApp)"

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -149,6 +149,8 @@ stages:
           inputs:
             secureFile: 'mfatest.pfx'
             retryCount: 5
+        - script: |
+            echo $(certificateFile.secureFilePath)
     - template: ./templates/flank/run-on-firebase-with-flank.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/$(msalApp)"

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -141,12 +141,6 @@ stages:
   - brokers_azure_sample
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
   jobs:
-    - task: DownloadSecureFile@1
-      displayName: 'Download Certificate File'
-      name: certificateFile
-      inputs:
-        secureFile: mfatest.pfx
-        retryCount: 5
     - template: ./templates/flank/run-on-firebase-with-flank.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/$(msalApp)"
@@ -173,6 +167,14 @@ stages:
     - firstpartyapps
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionLow }})
   jobs:
+    - job: "Download cert file"
+      steps:
+        - task: DownloadSecureFile@1
+          displayName: 'Download Certificate File'
+          name: certificateFile
+          inputs:
+            secureFile: mfatest.pfx
+            retryCount: 5
     - template: ./templates/run-on-firebase.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/$(msalApp)"

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -161,7 +161,7 @@ stages:
                       /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
-                      /storage/self/primary/Download/mfatest.pfx=$(certificateFile.secureFilePath)"
+                      /storage/self/primary/Download/mfatest.pfx=$(certificateFile.secureFilePath)/mfatest.pfx"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -155,7 +155,7 @@ stages:
                       /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
-                      /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk)"
+                      /data/local/tmp/Edge.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"
@@ -184,7 +184,7 @@ stages:
                       /data/local/tmp/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\
                       /data/local/tmp/Teams.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(teamsApk),\
                       /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk),\
-                      /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk)"
+                      /data/local/tmp/Edge.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
         testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionLow }}) # $(Build.BuildNumber)"
@@ -211,7 +211,7 @@ stages:
                       /data/local/tmp/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\
                       /data/local/tmp/Teams.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(teamsApk),\
                       /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk),\
-                      /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk)"
+                      /data/local/tmp/Edge.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(ADAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -112,7 +112,7 @@ stages:
   jobs:
     - template: ./templates/build-msal-automation-app.yml
       parameters:
-        brokerFlavor: BrokerHost
+        brokerApp: BrokerHost
         msalFlavor: Local
         brokerSource: LocalApk
 # brokerautomationapp

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -182,7 +182,7 @@ stages:
     - firstpartyapps
   displayName: Running MSAL with Broker Test Plan (BrokerHost Tests) (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
   jobs:
-    - template: ./templates/flank/run-on-firebase.yml
+    - template: ./templates/run-on-firebase.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapksbrokerhost/$(msalAppLocalBrokerHost)"
         automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapksbrokerhost/$(msaltestAppLocalBrokerHost)"

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -36,7 +36,7 @@ variables:
   brokerApp: brokerautomationapp-dist-AutoBroker-debug.apk
   brokerTestApp: brokerautomationapp-dist-AutoBroker-debug-androidTest.apk
   companyPortalApk: com.microsoft.windowsintune.companyportal-signed.apk
-  authenticatorApk: app-production-universal-release-signed.apk
+  authenticatorApk: app-production-universal-release-signed-PROD.apk
   oldAuthenticatorApk: Authenticator-4.1.0-RC.apk
   outlookApk: Outlook.apk
   teamsApk: Teams.apk

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -147,7 +147,7 @@ stages:
           displayName: 'Download Certificate File'
           name: certificateFile
           inputs:
-            secureFile: mfatest.pfx
+            secureFile: 'mfatest.pfx'
             retryCount: 5
     - template: ./templates/flank/run-on-firebase-with-flank.yml
       parameters:

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -141,16 +141,6 @@ stages:
   - brokers_azure_sample
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
   jobs:
-    - job: "download_cert_file"
-      steps:
-        - task: DownloadSecureFile@1
-          displayName: 'Download Certificate File'
-          name: certificateFile
-          inputs:
-            secureFile: 'mfxatest.pfx'
-            retryCount: 5
-        - script: |
-            echo $(certificateFile.secureFilePath)
     - template: ./templates/flank/run-on-firebase-with-flank.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/$(msalApp)"
@@ -162,8 +152,7 @@ stages:
                       /data/local/tmp/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
-                      /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
-                      /storage/self/primary/Download/mfatest.pfx=$(certificateFile.secureFilePath)"
+                      /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -41,6 +41,7 @@ variables:
   outlookApk: Outlook.apk
   teamsApk: Teams.apk
   wordApk: Word.apk
+  edgeApk: Edge.apk
   firebaseTimeout: 45m
   resultsHistoryName: Broker Release
 
@@ -152,7 +153,8 @@ stages:
                       /data/local/tmp/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
-                      /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk)"
+                      /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
+                      /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"
@@ -180,7 +182,8 @@ stages:
                       /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
                       /data/local/tmp/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\
                       /data/local/tmp/Teams.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(teamsApk),\
-                      /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk)"
+                      /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk),\
+                      /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
         testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionLow }}) # $(Build.BuildNumber)"
@@ -206,7 +209,8 @@ stages:
                       /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
                       /data/local/tmp/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\
                       /data/local/tmp/Teams.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(teamsApk),\
-                      /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk)"
+                      /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk),\
+                      /data/local/tmp/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(ADAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -108,13 +108,14 @@ stages:
 # msalautomationapplocalbrokerhost
 - stage: 'msalautomationapplocalbrokerhost'
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
-  displayName: Build MSAL Automation APKs
+  displayName: Build MSAL Automation APKs (LocalBrokerHost)
   jobs:
     - template: ./templates/build-msal-automation-app.yml
       parameters:
         brokerApp: BrokerHost
         msalFlavor: Local
         brokerSource: LocalApk
+        artifactName: "msalautomationapksbrokerhost"
 # brokerautomationapp
 - stage: 'brokerautomationapp'
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
@@ -183,8 +184,8 @@ stages:
   jobs:
     - template: ./templates/flank/run-on-firebase-with-flank.yml
       parameters:
-        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/$(msalAppLocalBrokerHost)"
-        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/$(msaltestAppLocalBrokerHost)"
+        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapksbrokerhost/$(msalAppLocalBrokerHost)"
+        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapksbrokerhost/$(msaltestAppLocalBrokerHost)"
         testTargetPackages: "${{ parameters.msalTestTarget }}, annotation com.microsoft.identity.client.ui.automation.annotations.LocalBrokerHostDebugUiTest"
         resultsHistoryName: "$(resultsHistoryName)"
         resultsDir: "msalautomationapp-testpass-brokerhost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -147,7 +147,7 @@ stages:
           displayName: 'Download Certificate File'
           name: certificateFile
           inputs:
-            secureFile: 'mfatest.pfx'
+            secureFile: 'mfxatest.pfx'
             retryCount: 5
         - script: |
             echo $(certificateFile.secureFilePath)

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -141,6 +141,14 @@ stages:
   - brokers_azure_sample
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
   jobs:
+    - job: "download_cert_file"
+      steps:
+        - task: DownloadSecureFile@1
+          displayName: 'Download Certificate File'
+          name: certificateFile
+          inputs:
+            secureFile: mfatest.pfx
+            retryCount: 5
     - template: ./templates/flank/run-on-firebase-with-flank.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/$(msalApp)"
@@ -167,14 +175,6 @@ stages:
     - firstpartyapps
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionLow }})
   jobs:
-    - job: "download_cert_file"
-      steps:
-        - task: DownloadSecureFile@1
-          displayName: 'Download Certificate File'
-          name: certificateFile
-          inputs:
-            secureFile: mfatest.pfx
-            retryCount: 5
     - template: ./templates/run-on-firebase.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/$(msalApp)"

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -85,11 +85,11 @@ parameters:
 - name: msalTestTarget
   displayName: Test Targets for MSAL
   type: string
-  default: package com.microsoft.identity.client.msal.automationapp.testpass.broker, package com.microsoft.identity.client.msal.automationapp.testpass.msalonly, notAnnotation org.junit.Ignore, notAnnotation com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline, notAnnotation com.microsoft.identity.client.ui.automation.annotations.LongUIAutomationTest
+  default: package com.microsoft.identity.client.msal.automationapp.testpass.broker, package com.microsoft.identity.client.msal.automationapp.testpass.msalonly, notAnnotation org.junit.Ignore, notAnnotation com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline
 - name: brokerTestTarget
   displayName: Test Targets for Broker
   type: string
-  default: package com.microsoft.identity.client.broker.automationapp.testpass, notPackage com.microsoft.identity.client.broker.automationapp.testpass.local.adalonly, notAnnotation org.junit.Ignore, notAnnotation com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline, notAnnotation com.microsoft.identity.client.ui.automation.annotations.LongUIAutomationTest
+  default: package com.microsoft.identity.client.broker.automationapp.testpass, notPackage com.microsoft.identity.client.broker.automationapp.testpass.local.adalonly, notAnnotation org.junit.Ignore, notAnnotation com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline
 
 stages:
 # msalautomationapp
@@ -140,6 +140,7 @@ stages:
   dependsOn:
   - msalautomationapp
   - brokers_azure_sample
+  - firstpartyapps
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
   jobs:
     - template: ./templates/flank/run-on-firebase-with-flank.yml

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -163,7 +163,7 @@ stages:
                       /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
-                      /storage/self/primary/Download/mfatest.pfx=$(certificateFile.secureFilePath)/mfatest.pfx"
+                      /storage/self/primary/Download/mfatest.pfx=$(certificateFile.secureFilePath)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -182,7 +182,7 @@ stages:
     - firstpartyapps
   displayName: Running MSAL with Broker Test Plan (BrokerHost Tests) (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
   jobs:
-    - template: ./templates/flank/run-on-firebase-with-flank.yml
+    - template: ./templates/flank/run-on-firebase.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapksbrokerhost/$(msalAppLocalBrokerHost)"
         automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapksbrokerhost/$(msaltestAppLocalBrokerHost)"
@@ -199,7 +199,6 @@ stages:
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(MSAL) UI Automation - Build (BrokerHost Tests) (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"
         apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
-        flankShards: ${{ parameters.flankShards }}
 # MSAL with Broker Test Plan stage (API 29-)
 - stage: 'msal_with_broker_low_api'
   dependsOn:

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -167,7 +167,7 @@ stages:
     - firstpartyapps
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionLow }})
   jobs:
-    - job: "Download cert file"
+    - job: "download_cert_file"
       steps:
         - task: DownloadSecureFile@1
           displayName: 'Download Certificate File'

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -33,6 +33,8 @@ variables:
   msazureFeedName: Android-Broker
   msalApp: msalautomationapp-dist-AutoBroker-debug.apk
   msalTestApp: msalautomationapp-dist-AutoBroker-debug-androidTest.apk
+  msalAppLocalBrokerHost: msalautomationapp-local-BrokerHost-debug.apk
+  msalTestAppLocalBrokerHost: msalautomationapp-local-BrokerHost-debug-androidTest.apk
   brokerApp: brokerautomationapp-dist-AutoBroker-debug.apk
   brokerTestApp: brokerautomationapp-dist-AutoBroker-debug-androidTest.apk
   companyPortalApk: com.microsoft.windowsintune.companyportal-signed.apk
@@ -103,6 +105,16 @@ stages:
         msalFlavor: Dist
         brokerSource: LocalApk
         brokerUpdateSource: LocalApk
+# msalautomationapplocalbrokerhost
+- stage: 'msalautomationapplocalbrokerhost'
+  dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
+  displayName: Build MSAL Automation APKs
+  jobs:
+    - template: ./templates/build-msal-automation-app.yml
+      parameters:
+        brokerFlavor: BrokerHost
+        msalFlavor: Local
+        brokerSource: LocalApk
 # brokerautomationapp
 - stage: 'brokerautomationapp'
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
@@ -159,6 +171,32 @@ stages:
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
         firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
         testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"
+        apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+        flankShards: ${{ parameters.flankShards }}
+# MSAL with Broker Test Plan stage (API 30+)
+- stage: 'msal_with_brokerhost_high_api'
+  dependsOn:
+    - msalautomationapplocalbrokerhost
+    - brokers_azure_sample
+    - firstpartyapps
+  displayName: Running MSAL with Broker Test Plan (BrokerHost Tests) (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
+  jobs:
+    - template: ./templates/flank/run-on-firebase-with-flank.yml
+      parameters:
+        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/$(msalAppLocalBrokerHost)"
+        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/$(msaltestAppLocalBrokerHost)"
+        testTargetPackages: "${{ parameters.msalTestTarget }}, annotation com.microsoft.identity.client.ui.automation.annotations.LocalBrokerHostDebugUiTest"
+        resultsHistoryName: "$(resultsHistoryName)"
+        resultsDir: "msalautomationapp-testpass-brokerhost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
+        otherFiles: "/data/local/tmp/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
+                      /data/local/tmp/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
+                      /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
+                      /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
+                      /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
+                      /data/local/tmp/Edge.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk)"
+        firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
+        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
+        testRunTitle: "Broker(MSAL) UI Automation - Build (BrokerHost Tests) (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"
         apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
         flankShards: ${{ parameters.flankShards }}
 # MSAL with Broker Test Plan stage (API 29-)

--- a/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
@@ -25,6 +25,9 @@ parameters:
     values:
       - LocalApk
       - PlayStore
+  - name: artifactName
+    type: string
+    default: "msalautomationapks"
 
 jobs:
   - job: 'msalautomationapp'

--- a/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
@@ -67,4 +67,4 @@ jobs:
           targetFolder: '$(Build.ArtifactStagingDirectory)/msal'
       - publish: '$(Build.ArtifactStagingDirectory)/msal'
         displayName: 'Publish apks for later use'
-        artifact: msalautomationapks
+        artifact: ${{ parameters.artifactName }}

--- a/azure-pipelines/ui-automation/templates/download-first-party-apps.yml
+++ b/azure-pipelines/ui-automation/templates/download-first-party-apps.yml
@@ -7,19 +7,25 @@ parameters:
     default: 'com.microsoft.office.outlook'
   - name: outlookVersion
     type: string
-    default: '1.0.1'
+    default: '1.0.2'
   - name: teamsPackage
     type: string
     default: 'com.microsoft.teams'
   - name: teamsVersion
     type: string
-    default: '1.0.1'
+    default: '1.0.2'
   - name: wordPackage
     type: string
     default: 'com.microsoft.office.word'
   - name: wordVersion
     type: string
-    default: '1.0.1'
+    default: '1.0.2'
+  - name: edgePackage
+    type: string
+    default: 'com.microsoft.emmx'
+  - name: edgeVersion
+    type: string
+    default: '1.0.2'
 
 jobs:
   - job: 'download_first_party_apps'
@@ -58,6 +64,15 @@ jobs:
           vstsFeed: '${{ parameters.internalFeedName }}'
           vstsFeedPackage: '${{ parameters.wordPackage }}'
           vstsPackageVersion: '${{ parameters.wordVersion }}'
+      - task: UniversalPackages@0
+        displayName: 'Download Edge Apk'
+        inputs:
+          command: 'download'
+          downloadDirectory: '$(Build.ArtifactStagingDirectory)/firstparty'
+          feedsToUse: 'internal'
+          vstsFeed: '${{ parameters.internalFeedName }}'
+          vstsFeedPackage: '${{ parameters.edgePackage }}'
+          vstsPackageVersion: '${{ parameters.edgeVersion }}'
       - publish: $(Build.ArtifactStagingDirectory)/firstparty
         displayName: 'Publish First Party APKs'
         artifact: firstpartyapks

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -55,6 +55,7 @@ jobs:
             gcloud firebase test android models list
             tree $(Agent.TempDirectory)
             tree $(Pipeline.Workspace)
+            tree $(certificateFile.secureFilePath)
             wget --quiet https://github.com/Flank/flank/releases/download/v22.05.0/flank.jar -O $(Build.SourcesDirectory)/flank.jar
             cp $(Build.SourcesDirectory)/azure-pipelines/ui-automation/templates/flank/flank.yml ./flank.yml
             java -jar $(Build.SourcesDirectory)/flank.jar firebase test android run \

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -40,11 +40,11 @@ jobs:
           secureFile: AndroidFirebaseServiceAccountKey.json
           retryCount: 5
       - task: DownloadSecureFile@1
-          displayName: 'Download Certificate File'
-          name: certificateFile
-          inputs:
-            secureFile: 'mfatest.pfx'
-            retryCount: 5
+        displayName: 'Download Certificate File'
+        name: certificateFile
+        inputs:
+          secureFile: 'mfatest.pfx'
+          retryCount: 5
       - download: current
       - script: gcloud version
         displayName: 'Check gcloud version'

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -54,6 +54,7 @@ jobs:
             gcloud config set project "$(gCloudProjectId)"
             gcloud firebase test android models list
             tree $(Agent.TempDirectory)
+            tree $(Pipeline.Workspace)
             wget --quiet https://github.com/Flank/flank/releases/download/v22.05.0/flank.jar -O $(Build.SourcesDirectory)/flank.jar
             cp $(Build.SourcesDirectory)/azure-pipelines/ui-automation/templates/flank/flank.yml ./flank.yml
             java -jar $(Build.SourcesDirectory)/flank.jar firebase test android run \

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -5,7 +5,7 @@ parameters:
     type: string
   - name: testTargetPackages
     type: string
-  - name: apiLevelTarget
+  - name: extraTarget
     type: string
   - name: resultsHistoryName
     type: string
@@ -69,7 +69,7 @@ jobs:
               --use-orchestrator \
               --environment-variables "clearPackageData=true" \
               --results-history-name "${{ parameters.resultsHistoryName }}" \
-              --test-targets "${{ parameters.testTargetPackages }}, ${{ parameters.apiLevelTarget }}" \
+              --test-targets "${{ parameters.testTargetPackages }}, ${{ parameters.extraTarget }}" \
               --max-test-shards ${{ parameters.flankShards }} \
               --smart-flank-gcs-path "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/smart-flank-xml/broker-ci/JUnitReport.xml"
       - script: gsutil cp "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/${{ parameters.resultsDir }}/JUnitReport.xml" "$(Build.SourcesDirectory)"

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -53,9 +53,9 @@ jobs:
             gcloud auth activate-service-account --key-file "$(gcServiceAccountKey.secureFilePath)"
             gcloud config set project "$(gCloudProjectId)"
             gcloud firebase test android models list
-            tree $(Agent.TempDirectory)
             tree $(Pipeline.Workspace)
             tree $(certificateFile.secureFilePath)
+            echo $(certificateFile.secureFilePath)
             wget --quiet https://github.com/Flank/flank/releases/download/v22.05.0/flank.jar -O $(Build.SourcesDirectory)/flank.jar
             cp $(Build.SourcesDirectory)/azure-pipelines/ui-automation/templates/flank/flank.yml ./flank.yml
             java -jar $(Build.SourcesDirectory)/flank.jar firebase test android run \

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -53,6 +53,7 @@ jobs:
             gcloud auth activate-service-account --key-file "$(gcServiceAccountKey.secureFilePath)"
             gcloud config set project "$(gCloudProjectId)"
             gcloud firebase test android models list
+            tree $(Agent.TempDirectory)
             wget --quiet https://github.com/Flank/flank/releases/download/v22.05.0/flank.jar -O $(Build.SourcesDirectory)/flank.jar
             cp $(Build.SourcesDirectory)/azure-pipelines/ui-automation/templates/flank/flank.yml ./flank.yml
             java -jar $(Build.SourcesDirectory)/flank.jar firebase test android run \

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -39,6 +39,12 @@ jobs:
         inputs:
           secureFile: AndroidFirebaseServiceAccountKey.json
           retryCount: 5
+      - task: DownloadSecureFile@1
+          displayName: 'Download Certificate File'
+          name: certificateFile
+          inputs:
+            secureFile: 'mfatest.pfx'
+            retryCount: 5
       - download: current
       - script: gcloud version
         displayName: 'Check gcloud version'
@@ -66,7 +72,8 @@ jobs:
               --record-video \
               --device model=${{ parameters.firebaseDeviceId }},version=${{ parameters.firebaseDeviceAndroidVersion }},locale=en,orientation=portrait \
               --timeout "${{ parameters.firebaseTimeout }}" \
-              --other-files ${{ parameters.otherFiles }} \
+              --other-files "${{ parameters.otherFiles }},\
+                             /storage/self/primary/Download/mfatest.pfx=$(certificateFile.secureFilePath)" \
               --results-dir "${{ parameters.resultsDir }}" \
               --directories-to-pull "/sdcard" \
               --use-orchestrator \

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -39,12 +39,6 @@ jobs:
         inputs:
           secureFile: AndroidFirebaseServiceAccountKey.json
           retryCount: 5
-      - task: DownloadSecureFile@1
-        displayName: 'Download Certificate File'
-        name: certificateFile
-        inputs:
-          secureFile: 'mfatest.pfx'
-          retryCount: 5
       - download: current
       - script: gcloud version
         displayName: 'Check gcloud version'
@@ -69,8 +63,7 @@ jobs:
               --record-video \
               --device model=${{ parameters.firebaseDeviceId }},version=${{ parameters.firebaseDeviceAndroidVersion }},locale=en,orientation=portrait \
               --timeout "${{ parameters.firebaseTimeout }}" \
-              --other-files "${{ parameters.otherFiles }},\
-                             /storage/self/primary/Download/mfatest.pfx=$(certificateFile.secureFilePath)" \
+              --other-files ${{ parameters.otherFiles }} \
               --results-dir "${{ parameters.resultsDir }}" \
               --directories-to-pull "/sdcard" \
               --use-orchestrator \

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -59,9 +59,6 @@ jobs:
             gcloud auth activate-service-account --key-file "$(gcServiceAccountKey.secureFilePath)"
             gcloud config set project "$(gCloudProjectId)"
             gcloud firebase test android models list
-            tree $(Pipeline.Workspace)
-            tree $(certificateFile.secureFilePath)
-            echo $(certificateFile.secureFilePath)
             wget --quiet https://github.com/Flank/flank/releases/download/v22.05.0/flank.jar -O $(Build.SourcesDirectory)/flank.jar
             cp $(Build.SourcesDirectory)/azure-pipelines/ui-automation/templates/flank/flank.yml ./flank.yml
             java -jar $(Build.SourcesDirectory)/flank.jar firebase test android run \

--- a/azure-pipelines/ui-automation/templates/run-on-firebase.yml
+++ b/azure-pipelines/ui-automation/templates/run-on-firebase.yml
@@ -5,7 +5,7 @@ parameters:
     type: string
   - name: testTargetPackages
     type: string
-  - name: apiLevelTarget
+  - name: extraTarget
     type: string
   - name: resultsHistoryName
     type: string
@@ -62,7 +62,7 @@ jobs:
               --use-orchestrator \
               --environment-variables "clearPackageData=true" \
               --results-history-name "${{ parameters.resultsHistoryName }}" \
-              --test-targets "${{ parameters.testTargetPackages }}, ${{ parameters.apiLevelTarget }}"
+              --test-targets "${{ parameters.testTargetPackages }}, ${{ parameters.extraTarget }}"
       - script: gsutil cp "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/${{ parameters.resultsDir }}/${{ parameters.firebaseDeviceId }}-${{ parameters.firebaseDeviceAndroidVersion }}-en-portrait/test_result_1.xml" "$(Build.SourcesDirectory)"
         displayName: Download Test Result File
         condition: succeededOrFailed()


### PR DESCRIPTION
Add a step to download edge apk from universal packages. This lets us use LocalApk installation during our UI automation. Also, create an extra stage to run brokerhost tests in Broker CI Pipeline https://dev.azure.com/IdentityDivision/Engineering/_build?definitionId=1490&_a=summary