### PR TITLE
Removed YubikitAndroidVersion 2.0.0 from versions.gradle

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -61,7 +61,6 @@ ext {
     bouncyCastleVersion = "1.67"
     oshiCoreVersion = "5.7.5"
     tokenShare = "1.6.1"
-    yubikitAndroidVersion = "2.0.0"
     intuneAppSdkVersion = "8.6.3"
     javaAssistVersion = "3.27.0-GA"
     yubikitAndroidVersion = "2.1.0"


### PR DESCRIPTION
## Summary
Removing the extra`yubikitAndroidVersion` value from versions/gradle. The only versions being used from YubiKit currently are     `yubikitAndroidVersion = "2.1.0"` and `yubikitPivVersion = "2.1.0"`.