### PR TITLE
Add script to promote packages in Ado maven feed

### DIFF
--- a/azure-pipelines/scripts/promote-packages.ps1
+++ b/azure-pipelines/scripts/promote-packages.ps1
@@ -1,0 +1,48 @@
+Param (
+    [Parameter(Mandatory = $true)][String]$PackagingPAT,
+    [Parameter(Mandatory = $false)][String]$PackageVersion = "",
+    [Parameter(Mandatory = $false)][String]$common4jVersion = $PackageVersion,
+    [Parameter(Mandatory = $false)][String]$commonVersion = $PackageVersion,
+    [Parameter(Mandatory = $false)][String]$broker4jVersion = $PackageVersion,
+    [Parameter(Mandatory = $false)][String]$adAccountsVersion = $PackageVersion,
+    [Parameter(Mandatory = $false)][String]$msalVersion = $PackageVersion,
+    [Parameter(Mandatory = $false)][String]$adalVersion = $PackageVersion,
+    [Parameter(Mandatory = $false)][String]$PromoteToView = "Prerelease",
+    [Parameter(Mandatory = $false)][String]$Organization = "identitydivision",
+    [Parameter(Mandatory = $false)][String]$FeedName="AndroidADAL"
+)
+
+#request uri
+$baseUri = "https://pkgs.dev.azure.com/$Organization";
+$promotePackagesApi = "_apis/packaging/feeds/$FeedName/maven/packagesbatch?api-version=7.1-preview.1"
+$promotePackagesUri = "$baseUri/$promotePackagesApi"
+
+# Auth header
+$base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("token:{0}" -f $PackagingPAT)))
+$authHeader = @{Authorization = ("Basic {0}" -f $base64AuthInfo)};
+
+# Request Body
+$MavenPackagesBatchRequest = New-Object PSObject -Property @{
+        data = @{ viewId = $PromoteToView }
+        operation = "promote"
+        packages = @(
+            @{ artifact = "common4j"; group = "com.microsoft.identity"; version = $common4jVersion},
+            @{ artifact = "common"; group = "com.microsoft.identity"; version = $commonVersion},
+            @{ artifact = "broker4j"; group = "com.microsoft.identity"; version = $broker4jVersion}
+            @{ artifact = "ad-accounts-for-android"; group = "com.microsoft.workplace"; version = $adAccountsVersion}
+            @{ artifact = "msal"; group = "com.microsoft.identity.client"; version = $msalVersion}
+            @{ artifact = "adal"; group = "com.microsoft.aad"; version = $adalVersion}
+        )
+   }
+
+$requestBody = $MavenPackagesBatchRequest | ConvertTo-Json
+
+# Call ADO Rest API
+try {
+    $Result = Invoke-RestMethod -Uri $promotePackagesUri -Method Post -ContentType "application/json" -Headers $authHeader -Body $requestBody;
+} catch {
+    if($_.ErrorDetails.Message){
+        Write-Error $_.ErrorDetails.Message
+    }
+    throw $_.Exception
+}


### PR DESCRIPTION
### What
Adding a script that can automatically promote packages to different views in ADO maven feed.

### Why
CP team currently require us to promote our libs/pacakges to Prerelease/Release view in our internal Ado Maven feed before they can pull them in their feed. This is a manual process currently where an engineer has to manually promote all packages (total 6) to right views before they can be consumed by CP team. 
This is a blocker for our daily end to end pipeline which needs to generate a CP apk with our daily builds and run automation with it without requiring any manual step

### How
Added a new poweshell script that uses AzureDevOps REST API to promote packages.
We will consume this script in our daily pipeline to promote packages to "Prerelease" view

Another benefit is that the script can also be run standalone to promote packages, so it can be used to promote private builds in one step, as compared to promoting multiple packages individually from the UI

### Testing
verified locally by running the script to promote packages.

