### PR TITLE
Decreased powerlift version to 1.0.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -65,7 +65,7 @@ ext {
     javaAssistVersion = "3.27.0-GA"
     yubikitAndroidVersion = "2.1.0"
     yubikitPivVersion = "2.1.0"
-    powerliftAndroidVersion="1.0.1"
+    powerliftAndroidVersion="1.0.0"
 
     // TODO: adal automation test app.
     supportLibraryVersion = "27.1.+"


### PR DESCRIPTION
Issue : In this PR we have increased the powerlift dependency version to 1.0.1
But CP is still on 1.0.0
Powerlift has introduced a new parameter is one of the APIs that Company Portal is using and this breaks their code
Following is the link for error logs https://msazure.visualstudio.com/Intune/_build/results?buildId=67415997&view=logs&j=a278aee4-cbe4-50ba-a1ce-e023967d147f&t=0a2b62e7-61d5-5cbc-dca5-2aedcce99c58

Fix : Reverting my changes in this PR means that we bring the powerlift version back to 1.0.0
We will follow up with company portal team on when they can increase the powerlift version to 1.0.1