### PR TITLE
Multiple enhancements to daily release pipeline

### DIFF
--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -36,18 +36,19 @@ jobs:
     env:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
-      ENV_VSTS_MVN_OFFICE_ACCESSTOKEN: $(vstsOfficeMavenAccessToken)
   - task: Gradle@3
     displayName: Build ${{ parameters.project }}
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.assembleParams}}
     env:
+      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
   - task: Gradle@3
     displayName: Publish ${{ parameters.project }}
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.publishCmd}} ${{ parameters.publishParams}}
     env:
+      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
   - task: ComponentGovernanceComponentDetection@0
     inputs:
@@ -75,4 +76,3 @@ jobs:
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
         ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
-        ENV_VSTS_MVN_OFFICE_ACCESSTOKEN: $(vstsOfficeMavenAccessToken)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -53,6 +53,7 @@ jobs:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
   - task: ComponentGovernanceComponentDetection@0
+    enabled: false
     inputs:
       sourceScanPath: $(Build.SourcesDirectory)/${{ parameters.project }}/gradle/dependency-locks/
 - job: RunUnitTest${{ parameters.project }}

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -31,7 +31,6 @@ jobs:
     persistCredentials: True
   - task: Gradle@3
     displayName: Generate Lockfile ${{ parameters.project }}
-    enabled: false
     inputs:
       tasks: -q ${{ parameters.project }}:dependencies ${{ parameters.dependencyParams }}
     env:
@@ -52,7 +51,6 @@ jobs:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
   - task: ComponentGovernanceComponentDetection@0
-    enabled: false
     inputs:
       sourceScanPath: $(Build.SourcesDirectory)/${{ parameters.project }}/gradle/dependency-locks/
 - job: RunUnitTest${{ parameters.project }}

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -47,6 +47,7 @@ jobs:
       ENV_VSTS_MVN_OFFICE_ACCESSTOKEN: $(vstsOfficeMavenAccessToken)
   - task: Gradle@3
     displayName: Publish ${{ parameters.project }}
+    enabled: false
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.publishCmd}} ${{ parameters.publishParams}}
     env:

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -45,6 +45,7 @@ jobs:
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
   - task: Gradle@3
     displayName: Publish ${{ parameters.project }}
+    enabled: false
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.publishCmd}} ${{ parameters.publishParams}}
     env:

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -36,6 +36,7 @@ jobs:
     env:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
+      ENV_VSTS_MVN_OFFICE_ACCESSTOKEN: $(vstsOfficeMavenAccessToken)
   - task: Gradle@3
     displayName: Build ${{ parameters.project }}
     inputs:
@@ -43,6 +44,7 @@ jobs:
     env:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
+      ENV_VSTS_MVN_OFFICE_ACCESSTOKEN: $(vstsOfficeMavenAccessToken)
   - task: Gradle@3
     displayName: Publish ${{ parameters.project }}
     inputs:
@@ -50,6 +52,7 @@ jobs:
     env:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
+      ENV_VSTS_MVN_OFFICE_ACCESSTOKEN: $(vstsOfficeMavenAccessToken)
   - task: ComponentGovernanceComponentDetection@0
     inputs:
       sourceScanPath: $(Build.SourcesDirectory)/${{ parameters.project }}/gradle/dependency-locks/
@@ -72,7 +75,8 @@ jobs:
       displayName: Run Test ${{ parameters.project }}
       continueOnError: true
       inputs:
-        tasks: ${{ parameters.project }}:${{ parameters.testCmd}}  -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PvstsUsername=$(AndroidAuthClient-Internal-Maven-Username) -PvstsMavenAccessToken=$(AndroidAuthClient-Internal-Maven-Access-Token)
+        tasks: ${{ parameters.project }}:${{ parameters.testCmd}}  -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
         ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
+        ENV_VSTS_MVN_OFFICE_ACCESSTOKEN: $(vstsOfficeMavenAccessToken)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -21,7 +21,7 @@ parameters:
 
 jobs:
 - job: publish${{ parameters.project }}Libraries
-  displayName: ${{ parameters.project }} build & publish for android to internal maven feed
+  displayName: ${{ parameters.project }} build & publish
   pool:
     vmImage: ubuntu-latest
   variables:
@@ -56,6 +56,7 @@ jobs:
     inputs:
       sourceScanPath: $(Build.SourcesDirectory)/${{ parameters.project }}/gradle/dependency-locks/
 - job: RunUnitTest${{ parameters.project }}
+  displayName: ${{ parameters.project }} UnitTest
   pool:
     vmImage: ubuntu-latest
     variables:

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -46,7 +46,7 @@ jobs:
   - task: Gradle@3
     displayName: Build and Run Test ${{ parameters.project }}
     inputs:
-      tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.testCmd}} ${{ parameters.assembleParams}} -PlabSecret=$(AndroidAutomationRunnerAppSecret)
+      tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.testCmd}} ${{ parameters.assembleParams}} -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true
     env:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -83,18 +83,3 @@ jobs:
       inputs:
         summaryFileLocation: '$(Build.SourcesDirectory)/${{ parameters.project }}/build/reports/jacoco/${{ parameters.testCmd }}/${{ parameters.testCmd }}.xml'
         reportDirectory: '$(Build.SourcesDirectory)/${{ parameters.project }}/build/reports/jacoco/${{ parameters.testCmd }}/html'
-#- job: RunInstrumentedTests${{ parameters.project }}
-#  condition: ne(${{ parameters.instrumentedTestBuild }}, ''))
-#  pool:
-#    vmImage: ubuntu-latest
-#    variables:
-#      - group: AndroidAuthClientVariables
-#  steps:
-#    - checkout: self
-#      persistCredentials: True
-#    - task: PowerShell@2
-#      displayName: Queue and wait for Instrumented test pipeline
-#      inputs:
-#        filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-#        arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId "${{parameters.instrumentedTestBuild}}"'
-#        workingDirectory: '$(Build.SourcesDirectory)'

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -77,6 +77,11 @@ jobs:
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
         ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
+    - task: PublishCodeCoverageResults@1
+      displayName: Publish Code Coverage Report
+      inputs:
+        summaryFileLocation: '$(Build.SourcesDirectory)/${{ parameters.project }}/build/reports/jacoco/${{ parameters.testCmd }}/${{ parameters.testCmd }}.xml'
+        reportDirectory: '$(Build.SourcesDirectory)/${{ parameters.project }}/build/reports/jacoco/${{ parameters.testCmd }}/html'
 #- job: RunInstrumentedTests${{ parameters.project }}
 #  condition: ne(${{ parameters.instrumentedTestBuild }}, ''))
 #  pool:

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -29,13 +29,6 @@ jobs:
   steps:
   - checkout: ${{ parameters.repository }}
     persistCredentials: True
-  - task: AzureKeyVault@2
-    displayName: 'Get Key vault AndroidAutomationRunnerAppSecret'
-    inputs:
-      azureSubscription: 'MSIDLABS_ANDROID_KV'
-      KeyVaultName: 'ADALTestInfo'
-      SecretsFilter: 'AndroidAutomationRunnerAppSecret'
-      RunAsPreJob: false
   - task: Gradle@3
     displayName: Generate Lockfile ${{ parameters.project }}
     inputs:
@@ -44,9 +37,9 @@ jobs:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
   - task: Gradle@3
-    displayName: Build and Run Test ${{ parameters.project }}
+    displayName: Build ${{ parameters.project }}
     inputs:
-      tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.testCmd}} ${{ parameters.assembleParams}} -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true
+      tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.assembleParams}}
     env:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
@@ -60,3 +53,23 @@ jobs:
   - task: ComponentGovernanceComponentDetection@0
     inputs:
       sourceScanPath: $(Build.SourcesDirectory)/${{ parameters.project }}/gradle/dependency-locks/
+- job: RunUnitTest${{ parameters.project }}
+  pool:
+    vmImage: windows-2022
+    variables:
+      - group: AndroidAuthClientVariables
+  steps:
+    - checkout: ${{ parameters.repository }}
+      persistCredentials: True
+    - task: AzureKeyVault@2
+      displayName: 'Get Key vault AndroidAutomationRunnerAppSecret'
+      inputs:
+        azureSubscription: 'MSIDLABS_ANDROID_KV'
+        KeyVaultName: 'ADALTestInfo'
+        SecretsFilter: 'AndroidAutomationRunnerAppSecret'
+        RunAsPreJob: false
+    - task: Gradle@3
+      displayName: Run Test ${{ parameters.project }}
+      continueOnError: true
+      inputs:
+        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -72,7 +72,7 @@ jobs:
       displayName: Run Test ${{ parameters.project }}
       continueOnError: true
       inputs:
-        tasks: ${{ parameters.project }}:${{ parameters.testCmd}}  -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true
+        tasks: ${{ parameters.project }}:${{ parameters.testCmd}}  -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
         testRunTitle: '${{ parameters.project }}_UnitTests'
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -76,3 +76,18 @@ jobs:
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
         ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
+#- job: RunInstrumentedTests${{ parameters.project }}
+#  condition: ne(${{ parameters.instrumentedTestBuild }}, ''))
+#  pool:
+#    vmImage: ubuntu-latest
+#    variables:
+#      - group: AndroidAuthClientVariables
+#  steps:
+#    - checkout: self
+#      persistCredentials: True
+#    - task: PowerShell@2
+#      displayName: Queue and wait for Instrumented test pipeline
+#      inputs:
+#        filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
+#        arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId "${{parameters.instrumentedTestBuild}}"'
+#        workingDirectory: '$(Build.SourcesDirectory)'

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -55,7 +55,7 @@ jobs:
       sourceScanPath: $(Build.SourcesDirectory)/${{ parameters.project }}/gradle/dependency-locks/
 - job: RunUnitTest${{ parameters.project }}
   pool:
-    vmImage: windows-2022
+    vmImage: ubuntu-latest
     variables:
       - group: AndroidAuthClientVariables
   steps:
@@ -72,4 +72,4 @@ jobs:
       displayName: Run Test ${{ parameters.project }}
       continueOnError: true
       inputs:
-        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true
+        tasks: ${{ parameters.project }}:${{ parameters.testCmd}}  -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -46,7 +46,6 @@ jobs:
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
   - task: Gradle@3
     displayName: Publish ${{ parameters.project }}
-    enabled: false
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.publishCmd}} ${{ parameters.publishParams}}
     env:

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -6,6 +6,8 @@ parameters:
 - name: project
 - name: assembleCmd
   default: assemble
+- name: testCmd
+  default: test
 - name: publishCmd
   default: publish
 - name: dependencyParams
@@ -27,6 +29,13 @@ jobs:
   steps:
   - checkout: ${{ parameters.repository }}
     persistCredentials: True
+  - task: AzureKeyVault@2
+    displayName: 'Get Key vault AndroidAutomationRunnerAppSecret'
+    inputs:
+      azureSubscription: 'MSIDLABS_ANDROID_KV'
+      KeyVaultName: 'ADALTestInfo'
+      SecretsFilter: 'AndroidAutomationRunnerAppSecret'
+      RunAsPreJob: false
   - task: Gradle@3
     displayName: Generate Lockfile ${{ parameters.project }}
     inputs:
@@ -35,9 +44,9 @@ jobs:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
   - task: Gradle@3
-    displayName: Build ${{ parameters.project }}
+    displayName: Build and Run Test ${{ parameters.project }}
     inputs:
-      tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.assembleParams}}
+      tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.testCmd}} ${{ parameters.assembleParams}} -PlabSecret=$(AndroidAutomationRunnerAppSecret)
     env:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -42,18 +42,13 @@ jobs:
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.assembleParams}}
     env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
-      ENV_VSTS_MVN_OFFICE_ACCESSTOKEN: $(vstsOfficeMavenAccessToken)
   - task: Gradle@3
     displayName: Publish ${{ parameters.project }}
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.publishCmd}} ${{ parameters.publishParams}}
     env:
-      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
-      ENV_VSTS_MVN_OFFICE_ACCESSTOKEN: $(vstsOfficeMavenAccessToken)
   - task: ComponentGovernanceComponentDetection@0
     inputs:
       sourceScanPath: $(Build.SourcesDirectory)/${{ parameters.project }}/gradle/dependency-locks/

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -42,17 +42,17 @@ jobs:
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.assembleParams}}
     env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
-      ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
+      ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
       ENV_VSTS_MVN_OFFICE_ACCESSTOKEN: $(vstsOfficeMavenAccessToken)
   - task: Gradle@3
     displayName: Publish ${{ parameters.project }}
-    enabled: false
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.publishCmd}} ${{ parameters.publishParams}}
     env:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
-      ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
+      ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
       ENV_VSTS_MVN_OFFICE_ACCESSTOKEN: $(vstsOfficeMavenAccessToken)
   - task: ComponentGovernanceComponentDetection@0
     inputs:
@@ -79,5 +79,5 @@ jobs:
         tasks: ${{ parameters.project }}:${{ parameters.testCmd}}  -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
-        ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)
+        ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
         ENV_VSTS_MVN_OFFICE_ACCESSTOKEN: $(vstsOfficeMavenAccessToken)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -73,6 +73,7 @@ jobs:
       continueOnError: true
       inputs:
         tasks: ${{ parameters.project }}:${{ parameters.testCmd}}  -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true
+        testRunTitle: '${{ parameters.project }}_UnitTests'
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
         ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -31,6 +31,7 @@ jobs:
     persistCredentials: True
   - task: Gradle@3
     displayName: Generate Lockfile ${{ parameters.project }}
+    enabled: false
     inputs:
       tasks: -q ${{ parameters.project }}:dependencies ${{ parameters.dependencyParams }}
     env:

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -72,7 +72,7 @@ jobs:
       displayName: Run Test ${{ parameters.project }}
       continueOnError: true
       inputs:
-        tasks: ${{ parameters.project }}:${{ parameters.testCmd}}  -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true
+        tasks: ${{ parameters.project }}:${{ parameters.testCmd}}  -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PvstsUsername=$(AndroidAuthClient-Internal-Maven-Username) -PvstsMavenAccessToken=$(AndroidAuthClient-Internal-Maven-Access-Token)
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
         ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -73,3 +73,6 @@ jobs:
       continueOnError: true
       inputs:
         tasks: ${{ parameters.project }}:${{ parameters.testCmd}}  -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true
+      env:
+        ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
+        ${{ parameters.vstsMvnAndroidAccessToken }}: $(AndroidAuthClient-Internal-Maven-Access-Token)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -116,7 +116,6 @@ stages:
     parameters:
       repository: broker
       project: broker4j
-      testCmd: broker4jUnitTestCoverageReport
       publishCmd: publishAarPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(common4jVersionParam) $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam) $(labApiUtilitiesVersionParam)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -310,4 +310,30 @@ stages:
             workingDirectory: '$(Build.SourcesDirectory)'
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+  # Msal - Instrumented tests
+- stage: 'runCommonInstrumentedTests'
+  displayName: Common Instrumented Tests
+  jobs:
+    - job:
+      displayName: Trigger Common Instrumented Run
+      steps:
+        - checkout: self
+          persistCredentials: True
+        - task: PowerShell@2
+          displayName: Queue and wait for Common Instrumented tests pipeline
+          continueOnError: true
+          inputs:
+            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
+            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId 1262 -BuildIdOutputVar "commonInstrumentedTestsBuildId"'
+            workingDirectory: '$(Build.SourcesDirectory)'
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        - task: PowerShell@2
+          displayName: Import Broker E2E Automation results
+          inputs:
+            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/import-testResults.ps1'
+            arguments: '-AdoPAT "$env:SYSTEM_ACCESSTOKEN" -SourceBuildId $(commonInstrumentedTestsBuildId) -TargetBuildId $(Build.BuildId)'
+            workingDirectory: '$(Build.SourcesDirectory)'
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 ...

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -105,6 +105,17 @@ stages:
       publishParams: $(projVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
+  - job: InstumentedTest
+    steps:
+    - checkout: common
+      persistCredentials: True
+    - task: Gradle@3
+      displayName: Run Instrumented Test comon
+      continueOnError: true
+      inputs:
+        tasks: "common:connectedLocalDebugAndroidTest -i -Psugar=true"
+      env:
+        ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN: $(System.AccessToken)
 # Broker4j - Build and publish
 - stage: 'publishBroke4jLibraries'
   displayName: Broker4j - Build and publish

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -71,7 +71,6 @@ stages:
       project: LabApiUtilities
       dependencyParams: $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam)
-      testCmd: ""
       publishParams: $(projVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
@@ -85,7 +84,6 @@ stages:
       repository: common
       project: common4j
       dependencyParams: $(javaProjectDependencyParam)
-      testCmd: ""
       assembleParams: $(projVersionParam)
       publishParams: $(projVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -285,6 +285,7 @@ stages:
           persistCredentials: True
         - task: PowerShell@2
           displayName: Queue and wait for Broker E2E Automation pipeline
+          continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
             arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId "1490" -Branch "master" -BuildIdOutputVar "brokerAutomationBuildId"'

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -109,6 +109,26 @@ stages:
     steps:
     - checkout: common
       persistCredentials: True
+    - task: CacheBeta@0
+      displayName: 'Caching System Images for AVD'
+      inputs:
+        key: 'AVD_IMAGES_PIXEL_28'
+        path: '$(ANDROID_HOME)/system-images'
+        cacheHitVar: 'AVD_IMAGES_RESTORED'
+      continueOnError: true
+      condition: succeededOrFailed()
+    - bash: |
+        echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-28;google_apis;x86'
+      displayName: 'Download and install emulator image'
+      condition: ne(variables.AVD_IMAGES_RESTORED, 'true')
+    - bash: |
+        echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n android_emulator -k 'system-images;android-28;google_apis;x86' -d 17 --force
+        echo "Emulator created successfully $(ANDROID_HOME/emulator/emulator -list-avds), launching it"
+        nohup $ANDROID_HOME/emulator/emulator -avd android_emulator -skin 1080x1920 -no-snapshot -no-audio -no-boot-anim -accel auto -gpu auto -qemu -lcd-density 420 > /dev/null 2>&1 &
+        $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done'
+        $ANDROID_HOME/platform-tools/adb devices
+        echo "Emulator started"
+      displayName: 'Create and start emulator'
     - task: Gradle@3
       displayName: Run Instrumented Test comon
       continueOnError: true

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -296,7 +296,7 @@ stages:
           displayName: Import Broker E2E Automation results
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/import-testResults.ps1'
-            arguments: '-AdoPAT "$env:SYSTEM_ACCESSTOKEN" -SourceBuildId $brokerAutomationBuildId -TargetBuildId $(Build.BuildId)'
+            arguments: '-AdoPAT "$env:SYSTEM_ACCESSTOKEN" -SourceBuildId $(brokerAutomationBuildId) -TargetBuildId $(Build.BuildId)'
             workingDirectory: '$(Build.SourcesDirectory)'
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -121,7 +121,7 @@ stages:
       repository: broker
       project: AADAuthenticator
       assembleCmd: assembleDist
-      testCmd: distDebugAADAuthenticatorUnitTestCoverageReport
+      testCmd: localDebugAADAuthenticatorUnitTestCoverageReport
       publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -62,18 +62,18 @@ variables:
 
 stages:
 # :LabApiUtilities - Build and publish
-- stage: 'publishLabApiUtilitiesLibraries'
-  displayName: LabApiUtilities - Build and publish
-  jobs:
-  - template: assemble&publish.yml
-    parameters:
-      repository: common
-      project: LabApiUtilities
-      dependencyParams: $(javaProjectDependencyParam)
-      assembleParams: $(projVersionParam)
-      publishParams: $(projVersionParam)
-      vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
-      vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
+#- stage: 'publishLabApiUtilitiesLibraries'
+#  displayName: LabApiUtilities - Build and publish
+#  jobs:
+#  - template: assemble&publish.yml
+#    parameters:
+#      repository: common
+#      project: LabApiUtilities
+#      dependencyParams: $(javaProjectDependencyParam)
+#      assembleParams: $(projVersionParam)
+#      publishParams: $(projVersionParam)
+#      vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
+#      vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
 # Common4j - Build and publish
 - stage: 'publishCommon4jLibraries'
   displayName: Common4j - Build and publish
@@ -109,7 +109,6 @@ stages:
 - stage: 'publishBroke4jLibraries'
   displayName: Broker4j - Build and publish
   dependsOn: 
-  - publishLabApiUtilitiesLibraries
   - publishCommon4jLibraries
   jobs:
   - template: assemble&publish.yml
@@ -118,8 +117,8 @@ stages:
       project: broker4j
       publishCmd: publishAarPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(common4jVersionParam) $(javaProjectDependencyParam)
-      assembleParams: $(projVersionParam) $(common4jVersionParam) $(labApiUtilitiesVersionParam)
-      publishParams: $(projVersionParam) $(common4jVersionParam) $(labApiUtilitiesVersionParam)
+      assembleParams: $(projVersionParam) $(common4jVersionParam)
+      publishParams: $(projVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
 # Broker - Build and publish
@@ -134,7 +133,7 @@ stages:
       repository: broker
       project: AADAuthenticator
       assembleCmd: assembleDist
-      testCmd: localDebugAADAuthenticatorUnitTestCoverageReport
+      testCmd: testDistReleaseUnitTest
       publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -287,7 +287,7 @@ stages:
           displayName: Queue and wait for Broker E2E Automation pipeline
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId "1490" -Branch "master" -BuildIdOutputVar="brokerAutomationBuildId"'
+            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId "1490" -Branch "master" -BuildIdOutputVar "brokerAutomationBuildId"'
             workingDirectory: '$(Build.SourcesDirectory)'
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -52,9 +52,9 @@ variables:
   ${{ else }}:
     versionNumber:  ${{ parameters.customVersionNumber }}
   projVersionParam: -PprojVersion=$(versionNumber)
-  common4jVersionParam: "" #-PdistCommon4jVersion=$(versionNumber)
-  broker4jVersionParam: "" #-PdistBroker4jVersion=$(versionNumber)
-  commonVersionParam: "" #-PdistCommonVersion=$(versionNumber)
+  common4jVersionParam: -PdistCommon4jVersion=$(versionNumber)
+  broker4jVersionParam: -PdistBroker4jVersion=$(versionNumber)
+  commonVersionParam: -PdistCommonVersion=$(versionNumber)
   linuxBrokerVersion: -PlinuxBrokerVersion=$(versionNumber)
   androidProjectDependencyParam: --configuration=distReleaseRuntimeClasspath --write-locks
   javaProjectDependencyParam: --configuration=runtimeClasspath --write-locks
@@ -263,9 +263,9 @@ stages:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
             arguments: '-OrganizationUrl "https://msazure.visualstudio.com/" -Project "One" -PipelinePAT "$(pipelinepat)" -BuildDefinitionId "237369" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(versionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "$(authenticatorBranch)"'
             workingDirectory: '$(Build.SourcesDirectory)'
-# BrokerApk - Company porta Queue pipeline
+# BrokerApk - Company portal Queue pipeline
 - stage: 'queueCompanyPortalPipeline'
-  displayName: Authenticator Broker Apk Generation
+  displayName: Company Portal Broker Apk Generation
   dependsOn: promotePackages
   jobs:
     - job: queue_build_CompanyPortal

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -310,30 +310,4 @@ stages:
             workingDirectory: '$(Build.SourcesDirectory)'
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-  # Msal - Instrumented tests
-- stage: 'runCommonInstrumentedTests'
-  displayName: Common Instrumented Tests
-  jobs:
-    - job:
-      displayName: Trigger Common Instrumented Run
-      steps:
-        - checkout: self
-          persistCredentials: True
-        - task: PowerShell@2
-          displayName: Queue and wait for Common Instrumented tests pipeline
-          continueOnError: true
-          inputs:
-            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId 1262 -BuildIdOutputVar "commonInstrumentedTestsBuildId"'
-            workingDirectory: '$(Build.SourcesDirectory)'
-          env:
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        - task: PowerShell@2
-          displayName: Import Broker E2E Automation results
-          inputs:
-            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/import-testResults.ps1'
-            arguments: '-AdoPAT "$env:SYSTEM_ACCESSTOKEN" -SourceBuildId $(commonInstrumentedTestsBuildId) -TargetBuildId $(Build.BuildId)'
-            workingDirectory: '$(Build.SourcesDirectory)'
-          env:
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 ...

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -58,8 +58,7 @@ variables:
   linuxBrokerVersion: -PlinuxBrokerVersion=$(versionNumber)
   androidProjectDependencyParam: --configuration=distReleaseRuntimeClasspath --write-locks
   javaProjectDependencyParam: --configuration=runtimeClasspath --write-locks
-  brokerAutomationPipelineId: 1382
-  #brokerAutomationPipelineId: 1490 broker-ci
+  brokerAutomationPipelineId: 1490
 
 stages:
 # Common4j - Build and publish

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -71,6 +71,7 @@ stages:
       project: LabApiUtilities
       dependencyParams: $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam)
+      testCmd: ""
       publishParams: $(projVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
@@ -84,6 +85,7 @@ stages:
       repository: common
       project: common4j
       dependencyParams: $(javaProjectDependencyParam)
+      testCmd: ""
       assembleParams: $(projVersionParam)
       publishParams: $(projVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -59,6 +59,8 @@ variables:
   androidProjectDependencyParam: --configuration=distReleaseRuntimeClasspath --write-locks
   javaProjectDependencyParam: --configuration=runtimeClasspath --write-locks
   brokerAutomationPipelineId: 1490
+  authenticatorBranch: "broker/continuous-integration"
+  companyPortalBranch: "broker/continuous-integration"
 
 stages:
 # Common4j - Build and publish

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -98,6 +98,7 @@ stages:
       repository: common
       project: common
       assembleCmd: assembleDist
+      testCmd: testDistReleaseUnitTest
       publishCmd: publishDistReleasePublicationToVsts-maven-adal-androidRepository
       dependencyParams:  $(common4jVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam)
@@ -133,6 +134,7 @@ stages:
       repository: broker
       project: AADAuthenticator
       assembleCmd: assembleDist
+      testCmd: testDistReleaseUnitTest
       publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
@@ -199,6 +201,7 @@ stages:
       repository: msal
       project: msal
       assembleCmd: assembleDistRelease
+      testCmd: testDistReleaseUnitTest
       publishCmd: publishMsalPublicationToVsts-maven-adal-androidRepository 
       dependencyParams: $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(commonVersionParam)
@@ -215,6 +218,7 @@ stages:
       repository: adal
       project: adal
       assembleCmd: assembleDist
+      testCmd: testDistReleaseUnitTest
       publishCmd: publishAdalPublicationToVsts-maven-adal-androidRepository 
       dependencyParams: $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(commonVersionParam)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -143,7 +143,7 @@ stages:
       repository: broker
       project: LinuxBroker
       publishCmd: publishAarPublicationToVsts-maven-adal-androidRepository
-      testCmd: ""
+      testCmd: linuxBrokerUnitTestCoverageReport
       dependencyParams: $(broker4jVersionParam) $(common4jVersionParam) $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
       publishParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -98,7 +98,7 @@ stages:
       repository: common
       project: common
       assembleCmd: assembleDist
-      testCmd: testDistReleaseUnitTest
+      testCmd: testLocalDebugUnitTest
       publishCmd: publishDistReleasePublicationToVsts-maven-adal-androidRepository
       dependencyParams:  $(common4jVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam)
@@ -116,6 +116,7 @@ stages:
     parameters:
       repository: broker
       project: broker4j
+      testCmd: broker4jUnitTestCoverageReport
       publishCmd: publishAarPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(common4jVersionParam) $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam) $(labApiUtilitiesVersionParam)
@@ -134,7 +135,7 @@ stages:
       repository: broker
       project: AADAuthenticator
       assembleCmd: assembleDist
-      testCmd: testDistReleaseUnitTest
+      testCmd: localDebugAADAuthenticatorUnitTestCoverageReport
       publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
@@ -153,6 +154,7 @@ stages:
       repository: broker
       project: LinuxBroker
       publishCmd: publishAarPublicationToVsts-maven-adal-androidRepository
+      testCmd: ""
       dependencyParams: $(broker4jVersionParam) $(common4jVersionParam) $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
       publishParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
@@ -201,7 +203,7 @@ stages:
       repository: msal
       project: msal
       assembleCmd: assembleDistRelease
-      testCmd: testDistReleaseUnitTest
+      testCmd: testLocalDebugUnitTest
       publishCmd: publishMsalPublicationToVsts-maven-adal-androidRepository 
       dependencyParams: $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(commonVersionParam)
@@ -218,7 +220,7 @@ stages:
       repository: adal
       project: adal
       assembleCmd: assembleDist
-      testCmd: testDistReleaseUnitTest
+      testCmd: testLocalDebugUnitTest
       publishCmd: publishAdalPublicationToVsts-maven-adal-androidRepository 
       dependencyParams: $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(commonVersionParam)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -221,14 +221,40 @@ stages:
       publishParams: $(projVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADAL_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN
-# BrokerApk - Queue pipeline
-- stage: 'queueBrokerApkPipeline'
-  displayName: Broker Apk Generation
+# Promote published packages
+- stage: 'promotePackages'
+  displayName: Promote published pacakges
   dependsOn:
     - publishMsal
     - publishAdal
     - publishCommonLibraries
     - publishBrokerLibraries
+  jobs:
+    - job: promote_packages
+      displayName: Promote Packages - Prerelease & Release
+      steps:
+        - checkout: self
+          persistCredentials: True
+        - task: PowerShell@2
+          displayName: Run script to promote packages - Prerelease
+          inputs:
+            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/promote-packages.ps1'
+            arguments: '-PackagingPAT "$env:SYSTEM_ACCESSTOKEN" -PackageVersion "$(Build.BuildNumber)"'
+            workingDirectory: '$(Build.SourcesDirectory)'
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        - task: PowerShell@2
+          displayName: Run script to promote packages - Release
+          inputs:
+            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/promote-packages.ps1'
+            arguments: '-PackagingPAT "$env:SYSTEM_ACCESSTOKEN" -PackageVersion "$(Build.BuildNumber)" -PromoteToView "Release"'
+            workingDirectory: '$(Build.SourcesDirectory)'
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+# BrokerApk - Queue pipeline
+- stage: 'queueBrokerApkPipeline'
+  displayName: Broker Apk Generation
+  dependsOn: promotePackages
   jobs:
     - job: queue_build
       displayName: BrokerApk - Trigger pipelines
@@ -241,7 +267,7 @@ stages:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
             arguments: '-OrganizationUrl "https://msazure.visualstudio.com/" -Project "One" -PipelinePAT "$(pipelinepat)" -BuildDefinitionId "237369" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(Build.BuildNumber)'', ''CommonVersion'': ''$(Build.BuildNumber)'', ''MsalVersion'': ''$(Build.BuildNumber)'', ''AdalVersion'': ''$(Build.BuildNumber)'' }" -Branch "broker/continuous-integration"'
             workingDirectory: '$(Build.SourcesDirectory)'
-  # Broker - E2E Automation
+# Broker - E2E Automation
 - stage: 'runBrokerE2EAutomation'
   displayName: Broker Automation Run
   dependsOn: queueBrokerApkPipeline

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -223,7 +223,7 @@ stages:
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN
 # Promote published packages
 - stage: 'promotePackages'
-  displayName: Promote published pacakges
+  displayName: Promote published packages
   dependsOn:
     - publishMsal
     - publishAdal
@@ -256,8 +256,8 @@ stages:
   displayName: Broker Apk Generation
   dependsOn: promotePackages
   jobs:
-    - job: queue_build
-      displayName: BrokerApk - Trigger pipelines
+    - job: queue_build_authenticator
+      displayName: Generate Authenticator Apk
       steps:
         - checkout: self
           persistCredentials: True
@@ -265,7 +265,18 @@ stages:
           displayName: Queue and wait for Authenticator Apk generation pipeline
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://msazure.visualstudio.com/" -Project "One" -PipelinePAT "$(pipelinepat)" -BuildDefinitionId "237369" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(Build.BuildNumber)'', ''CommonVersion'': ''$(Build.BuildNumber)'', ''MsalVersion'': ''$(Build.BuildNumber)'', ''AdalVersion'': ''$(Build.BuildNumber)'' }" -Branch "broker/continuous-integration"'
+            arguments: '-OrganizationUrl "https://msazure.visualstudio.com/" -Project "One" -PipelinePAT "$(pipelinepat)" -BuildDefinitionId "237369" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(versionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "$(authenticatorBranch)"'
+            workingDirectory: '$(Build.SourcesDirectory)'
+    - job: queue_build_CompanyPortal
+      displayName: Generate CompanyPortal Apk
+      steps:
+        - checkout: self
+          persistCredentials: True
+        - task: PowerShell@2
+          displayName: Queue and wait for Company Portal Apk generation pipeline
+          inputs:
+            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
+            arguments: '-OrganizationUrl "https://msazure.visualstudio.com/" -Project "Intune" -PipelinePAT "$(pipelinepat)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "237827" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(versionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "$(companyPortalBranch)"'
             workingDirectory: '$(Build.SourcesDirectory)'
 # Broker - E2E Automation
 - stage: 'runBrokerE2EAutomation'

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -52,9 +52,9 @@ variables:
   ${{ else }}:
     versionNumber:  ${{ parameters.customVersionNumber }}
   projVersionParam: -PprojVersion=$(versionNumber)
-  common4jVersionParam: -PdistCommon4jVersion=$(versionNumber)
-  broker4jVersionParam: -PdistBroker4jVersion=$(versionNumber)
-  commonVersionParam: -PdistCommonVersion=$(versionNumber)
+  common4jVersionParam: "" #-PdistCommon4jVersion=$(versionNumber)
+  broker4jVersionParam: "" #-PdistBroker4jVersion=$(versionNumber)
+  commonVersionParam: "" #-PdistCommonVersion=$(versionNumber)
   linuxBrokerVersion: -PlinuxBrokerVersion=$(versionNumber)
   androidProjectDependencyParam: --configuration=distReleaseRuntimeClasspath --write-locks
   javaProjectDependencyParam: --configuration=runtimeClasspath --write-locks

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -105,37 +105,37 @@ stages:
       publishParams: $(projVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
-  - job: InstumentedTest
-    steps:
-    - checkout: common
-      persistCredentials: True
-    - task: CacheBeta@0
-      displayName: 'Caching System Images for AVD'
-      inputs:
-        key: 'AVD_IMAGES_PIXEL_28'
-        path: '$(ANDROID_HOME)/system-images'
-        cacheHitVar: 'AVD_IMAGES_RESTORED'
-      continueOnError: true
-      condition: succeededOrFailed()
-    - bash: |
-        echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-28;google_apis;x86'
-      displayName: 'Download and install emulator image'
-      condition: ne(variables.AVD_IMAGES_RESTORED, 'true')
-    - bash: |
-        echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n android_emulator -k 'system-images;android-28;google_apis;x86' -d 17 --force
-        echo "Emulator created successfully $(ANDROID_HOME/emulator/emulator -list-avds), launching it"
-        nohup $ANDROID_HOME/emulator/emulator -avd android_emulator -skin 1080x1920 -no-snapshot -no-audio -no-boot-anim -accel auto -gpu auto -qemu -lcd-density 420 > /dev/null 2>&1 &
-        $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done'
-        $ANDROID_HOME/platform-tools/adb devices
-        echo "Emulator started"
-      displayName: 'Create and start emulator'
-    - task: Gradle@3
-      displayName: Run Instrumented Test comon
-      continueOnError: true
-      inputs:
-        tasks: "common:connectedLocalDebugAndroidTest -i -Psugar=true"
-      env:
-        ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN: $(System.AccessToken)
+#  - job: InstumentedTest
+#    steps:
+#    - checkout: common
+#      persistCredentials: True
+#    - task: CacheBeta@0
+#      displayName: 'Caching System Images for AVD'
+#      inputs:
+#        key: 'AVD_IMAGES_PIXEL_28'
+#        path: '$(ANDROID_HOME)/system-images'
+#        cacheHitVar: 'AVD_IMAGES_RESTORED'
+#      continueOnError: true
+#      condition: succeededOrFailed()
+#    - bash: |
+#        echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-28;google_apis;x86'
+#      displayName: 'Download and install emulator image'
+#      condition: ne(variables.AVD_IMAGES_RESTORED, 'true')
+#    - bash: |
+#        echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n android_emulator -k 'system-images;android-28;google_apis;x86' -d 17 --force
+#        echo "Emulator created successfully $(ANDROID_HOME/emulator/emulator -list-avds), launching it"
+#        nohup $ANDROID_HOME/emulator/emulator -avd android_emulator -skin 1080x1920 -no-snapshot -no-audio -no-boot-anim -accel auto -gpu auto -qemu -lcd-density 420 > /dev/null 2>&1 &
+#        $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done'
+#        $ANDROID_HOME/platform-tools/adb devices
+#        echo "Emulator started"
+#      displayName: 'Create and start emulator'
+#    - task: Gradle@3
+#      displayName: Run Instrumented Test comon
+#      continueOnError: true
+#      inputs:
+#        tasks: "common:connectedLocalDebugAndroidTest -i -Psugar=true"
+#      env:
+#        ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN: $(System.AccessToken)
 # Broker4j - Build and publish
 - stage: 'publishBroke4jLibraries'
   displayName: Broker4j - Build and publish

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -246,9 +246,9 @@ stages:
             workingDirectory: '$(Build.SourcesDirectory)'
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-# BrokerApk - Queue pipeline
-- stage: 'queueBrokerApkPipeline'
-  displayName: Broker Apk Generation
+# BrokerApk - Authenticator Queue pipeline
+- stage: 'queueAuthenticatorPipeline'
+  displayName: Authenticator Broker Apk Generation
   dependsOn: promotePackages
   jobs:
     - job: queue_build_authenticator
@@ -263,6 +263,11 @@ stages:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
             arguments: '-OrganizationUrl "https://msazure.visualstudio.com/" -Project "One" -PipelinePAT "$(pipelinepat)" -BuildDefinitionId "237369" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(versionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "$(authenticatorBranch)"'
             workingDirectory: '$(Build.SourcesDirectory)'
+# BrokerApk - Company porta Queue pipeline
+- stage: 'queueCompanyPortalPipeline'
+  displayName: Authenticator Broker Apk Generation
+  dependsOn: promotePackages
+  jobs:
     - job: queue_build_CompanyPortal
       displayName: Generate CompanyPortal Apk
       timeoutInMinutes: 120
@@ -278,7 +283,9 @@ stages:
 # Broker - E2E Automation
 - stage: 'runBrokerE2EAutomation'
   displayName: Broker Automation Run
-  dependsOn: queueBrokerApkPipeline
+  dependsOn:
+    - queueAuthenticatorPipeline
+    - queueCompanyPortalPipeline
   jobs:
     - job: trigger_automation
       displayName: Trigger Broker Automation Run

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -121,7 +121,7 @@ stages:
       repository: broker
       project: AADAuthenticator
       assembleCmd: assembleDist
-      testCmd: localDebugAADAuthenticatorUnitTestCoverageReport
+      testCmd: distDebugAADAuthenticatorUnitTestCoverageReport
       publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -61,19 +61,6 @@ variables:
   javaProjectDependencyParam: --configuration=runtimeClasspath --write-locks
 
 stages:
-# :LabApiUtilities - Build and publish
-#- stage: 'publishLabApiUtilitiesLibraries'
-#  displayName: LabApiUtilities - Build and publish
-#  jobs:
-#  - template: assemble&publish.yml
-#    parameters:
-#      repository: common
-#      project: LabApiUtilities
-#      dependencyParams: $(javaProjectDependencyParam)
-#      assembleParams: $(projVersionParam)
-#      publishParams: $(projVersionParam)
-#      vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
-#      vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
 # Common4j - Build and publish
 - stage: 'publishCommon4jLibraries'
   displayName: Common4j - Build and publish
@@ -105,37 +92,6 @@ stages:
       publishParams: $(projVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
-#  - job: InstumentedTest
-#    steps:
-#    - checkout: common
-#      persistCredentials: True
-#    - task: CacheBeta@0
-#      displayName: 'Caching System Images for AVD'
-#      inputs:
-#        key: 'AVD_IMAGES_PIXEL_28'
-#        path: '$(ANDROID_HOME)/system-images'
-#        cacheHitVar: 'AVD_IMAGES_RESTORED'
-#      continueOnError: true
-#      condition: succeededOrFailed()
-#    - bash: |
-#        echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-28;google_apis;x86'
-#      displayName: 'Download and install emulator image'
-#      condition: ne(variables.AVD_IMAGES_RESTORED, 'true')
-#    - bash: |
-#        echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n android_emulator -k 'system-images;android-28;google_apis;x86' -d 17 --force
-#        echo "Emulator created successfully $(ANDROID_HOME/emulator/emulator -list-avds), launching it"
-#        nohup $ANDROID_HOME/emulator/emulator -avd android_emulator -skin 1080x1920 -no-snapshot -no-audio -no-boot-anim -accel auto -gpu auto -qemu -lcd-density 420 > /dev/null 2>&1 &
-#        $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done'
-#        $ANDROID_HOME/platform-tools/adb devices
-#        echo "Emulator started"
-#      displayName: 'Create and start emulator'
-#    - task: Gradle@3
-#      displayName: Run Instrumented Test comon
-#      continueOnError: true
-#      inputs:
-#        tasks: "common:connectedLocalDebugAndroidTest -i -Psugar=true"
-#      env:
-#        ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN: $(System.AccessToken)
 # Broker4j - Build and publish
 - stage: 'publishBroke4jLibraries'
   displayName: Broker4j - Build and publish

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -58,6 +58,8 @@ variables:
   linuxBrokerVersion: -PlinuxBrokerVersion=$(versionNumber)
   androidProjectDependencyParam: --configuration=distReleaseRuntimeClasspath --write-locks
   javaProjectDependencyParam: --configuration=runtimeClasspath --write-locks
+  brokerAutomationPipelineId: 1382
+  #brokerAutomationPipelineId: 1490 broker-ci
 
 stages:
 # Common4j - Build and publish
@@ -288,7 +290,7 @@ stages:
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId "1490" -Branch "master" -BuildIdOutputVar "brokerAutomationBuildId"'
+            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId $(brokerAutomationPipelineId) -BuildIdOutputVar "brokerAutomationBuildId"'
             workingDirectory: '$(Build.SourcesDirectory)'
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -69,6 +69,7 @@ stages:
     parameters:
       repository: common
       project: common4j
+      testCmd: common4jUnitTestCoverageReport
       dependencyParams: $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam)
       publishParams: $(projVersionParam)
@@ -84,7 +85,7 @@ stages:
       repository: common
       project: common
       assembleCmd: assembleDist
-      testCmd: testLocalDebugUnitTest
+      testCmd: distDebugCommonUnitTestCoverageReport
       publishCmd: publishDistReleasePublicationToVsts-maven-adal-androidRepository
       dependencyParams:  $(common4jVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam)
@@ -101,6 +102,7 @@ stages:
     parameters:
       repository: broker
       project: broker4j
+      testCmd: broker4jUnitTestCoverageReport
       publishCmd: publishAarPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(common4jVersionParam) $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam)
@@ -119,7 +121,7 @@ stages:
       repository: broker
       project: AADAuthenticator
       assembleCmd: assembleDist
-      testCmd: testDistReleaseUnitTest
+      testCmd: distDebugAADAuthenticatorUnitTestCoverageReport
       publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(commonVersionParam)
@@ -187,7 +189,7 @@ stages:
       repository: msal
       project: msal
       assembleCmd: assembleDistRelease
-      testCmd: testLocalDebugUnitTest
+      testCmd: distDebugMsalUnitTestCoverageReport
       publishCmd: publishMsalPublicationToVsts-maven-adal-androidRepository 
       dependencyParams: $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(commonVersionParam)
@@ -204,7 +206,7 @@ stages:
       repository: adal
       project: adal
       assembleCmd: assembleDist
-      testCmd: testLocalDebugUnitTest
+      testCmd: testDistDebugUnitTest
       publishCmd: publishAdalPublicationToVsts-maven-adal-androidRepository 
       dependencyParams: $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(commonVersionParam)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -52,7 +52,6 @@ variables:
   ${{ else }}:
     versionNumber:  ${{ parameters.customVersionNumber }}
   projVersionParam: -PprojVersion=$(versionNumber)
-  labApiUtilitiesVersionParam: -PdistLabApiUtilitiesVersion=$(versionNumber)
   common4jVersionParam: -PdistCommon4jVersion=$(versionNumber)
   broker4jVersionParam: -PdistBroker4jVersion=$(versionNumber)
   commonVersionParam: -PdistCommonVersion=$(versionNumber)
@@ -283,7 +282,15 @@ stages:
           displayName: Queue and wait for Broker E2E Automation pipeline
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId "1490" -Branch "master"'
+            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId "1490" -Branch "master" -BuildIdOutputVar="brokerAutomationBuildId"'
+            workingDirectory: '$(Build.SourcesDirectory)'
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        - task: PowerShell@2
+          displayName: Import Broker E2E Automation results
+          inputs:
+            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/import-testResults.ps1'
+            arguments: '-AdoPAT "$env:SYSTEM_ACCESSTOKEN" -SourceBuildId $brokerAutomationBuildId -TargetBuildId $(Build.BuildId)'
             workingDirectory: '$(Build.SourcesDirectory)'
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -248,6 +248,7 @@ stages:
   jobs:
     - job: queue_build_authenticator
       displayName: Generate Authenticator Apk
+      timeoutInMinutes: 120
       steps:
         - checkout: self
           persistCredentials: True
@@ -259,6 +260,7 @@ stages:
             workingDirectory: '$(Build.SourcesDirectory)'
     - job: queue_build_CompanyPortal
       displayName: Generate CompanyPortal Apk
+      timeoutInMinutes: 120
       steps:
         - checkout: self
           persistCredentials: True
@@ -275,6 +277,7 @@ stages:
   jobs:
     - job: trigger_automation
       displayName: Trigger Broker Automation Run
+      timeoutInMinutes: 80
       steps:
         - checkout: self
           persistCredentials: True

--- a/azure-pipelines/scripts/import-testResults.ps1
+++ b/azure-pipelines/scripts/import-testResults.ps1
@@ -1,0 +1,66 @@
+Param (
+    [Parameter(Mandatory = $true)][String]$AdoPAT,
+    [Parameter(Mandatory = $false)][String]$Organization = "identitydivision",
+    [Parameter(Mandatory = $false)][String]$Project = "Engineering",
+    [Parameter(Mandatory = $true)][String]$SourceBuildId,
+    [Parameter(Mandatory = $true)][String]$TargetBuildId
+)
+
+
+#request Uris
+$apiVersion = "7.1-preview.3"
+$baseUri = "https://dev.azure.com/$Organization/$Project";
+$testRunUri = "$baseUri/_apis/test/runs?api-version=$apiVersion"
+
+$minLastUpdatedDate = Get-Date (Get-Date).AddHours(-4) -Format "MM/dd/yyyy hh:mm"
+$maxLastUpdatedDate = Get-Date -Format "MM/dd/yyyy hh:mm"
+$queryRunsUri = "$baseUri/_apis/test/runs?minLastUpdatedDate=$minLastUpdatedDate&maxLastUpdatedDate=$maxLastUpdatedDate&buildIds=$SourceBuildId&api-version=$apiVersion"
+
+# Auth header
+$base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("token:{0}" -f $AdoPAT)))
+$authHeader = @{Authorization = ("Basic {0}" -f $base64AuthInfo)};
+
+
+# Call ADO Rest APIs
+try {
+    Write-Host "Get TestResults from $SourceBuildId"
+    $testRuns = Invoke-RestMethod -Uri $queryRunsUri -Method Get -Headers $authHeader
+    foreach ($testRun in $testRuns.value) {
+        $testRunId = $testRun.id
+        $testResultsApi = "_apis/test/runs/$testRunId/results?api-version=$apiVersion"
+        $testResultsUri = "$baseUri/$testResultsApi"
+        $testResults  = Invoke-RestMethod -Uri $testResultsUri -Method Get -Headers $authHeader;
+
+        Write-Host "Create a new Test Run on the $TargetBuildId"
+        $createRunParam = New-Object PSObject -Property @{
+                            name = $testRun.name
+                            build = @{ id = "$TargetBuildId" }
+                            isAutomated = $testRun.isAutomated
+                       }
+
+        $createRunRequest = $createRunParam | ConvertTo-Json
+        $createRunResult = Invoke-RestMethod -Uri $testRunUri -ContentType "application/json" -Headers $authHeader -Method Post -Body $createRunRequest
+
+        $targetRunId = $createRunResult.id
+        Write-Host "Import the testResults $testRunId in new test run $targetRunId" 
+        
+        foreach ($testResult in $testResults.value) {
+            $testResult.testRun.id = $targetRunId
+        }
+
+        $targetRunUri = "$baseUri/_apis/test/runs/$($targetRunId)?api-version=$apiVersion"
+        $updateResultsUri = "$baseUri/_apis/test/runs/$targetRunId/results?api-version=$apiVersion"
+        $updateResultRequest = $testResults.value | ConvertTo-Json
+        Invoke-RestMethod -Uri $updateResultsUri -ContentType "application/json" -Headers $authHeader -Method Post -Body $updateResultRequest
+
+        Write-Host "Mark the new test run $targetRunId as completed"
+        $testRunCompleteRequest = @{state = "completed"} | ConvertTo-Json        
+        Invoke-RestMethod -Uri $targetRunUri -ContentType "application/json" -Headers $authHeader -Method Patch -Body $testRunCompleteRequest
+    }
+    
+} catch {
+    if($_.ErrorDetails.Message){
+        Write-Error $_.ErrorDetails.Message
+    }
+    throw $_.Exception
+}

--- a/azure-pipelines/scripts/import-testResults.ps1
+++ b/azure-pipelines/scripts/import-testResults.ps1
@@ -12,9 +12,10 @@ $apiVersion = "7.1-preview.3"
 $baseUri = "https://dev.azure.com/$Organization/$Project";
 $testRunUri = "$baseUri/_apis/test/runs?api-version=$apiVersion"
 
-$minLastUpdatedDate = Get-Date (Get-Date).AddHours(-4) -Format "MM/dd/yyyy hh:mm"
-$maxLastUpdatedDate = Get-Date -Format "MM/dd/yyyy hh:mm"
+$minLastUpdatedDate = Get-Date (Get-Date).AddDays(-1) -Format "MM/dd/yyyy"
+$maxLastUpdatedDate = Get-Date (Get-Date).AddDays(1) -Format "MM/dd/yyyy"
 $queryRunsUri = "$baseUri/_apis/test/runs?minLastUpdatedDate=$minLastUpdatedDate&maxLastUpdatedDate=$maxLastUpdatedDate&buildIds=$SourceBuildId&api-version=$apiVersion"
+Write-Host $queryRunsUri
 
 # Auth header
 $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("token:{0}" -f $AdoPAT)))

--- a/azure-pipelines/scripts/queue-build.ps1
+++ b/azure-pipelines/scripts/queue-build.ps1
@@ -60,7 +60,6 @@ $BuildStartTime= Get-Date
 do{
    try {
        $QueuedBuild = Invoke-RestMethod -Uri $getBuildUri -Method Get -ContentType "application/json" -Headers $authHeader;
-       
        Write-Host $($QueuedBuild.status)
        $BuildNotCompleted = ($($QueuedBuild.status) -eq "inProgress") -Or ($($QueuedBuild.status) -eq "notStarted")
        if($BuildNotCompleted){

--- a/azure-pipelines/scripts/queue-build.ps1
+++ b/azure-pipelines/scripts/queue-build.ps1
@@ -6,7 +6,8 @@ Param (
     [Parameter(Mandatory = $false)][String]$PipelineVariablesJson,
     [Parameter(Mandatory = $false)][String]$Branch,
     [Parameter(Mandatory = $false)][int]$WaitTimeoutInMinutes = 120,
-    [Parameter(Mandatory = $false)][int]$PollingIntervalInSeconds = 5 * 60
+    [Parameter(Mandatory = $false)][int]$PollingIntervalInSeconds = 5 * 60,
+    [Parameter(Mandatory = $false)][int]$BuildIdOutputVar=""
 )
 
 #request uri
@@ -52,7 +53,7 @@ $BuildStartTime= Get-Date
 do{
    try {
        $QueuedBuild = Invoke-RestMethod -Uri $getBuildUri -Method Get -ContentType "application/json" -Headers $authHeader;
-       if($BuildIdOutputVar -ne $null) {
+       if($BuildIdOutputVar -ne "") {
             Write-Host "##vso[task.setvariable variable=$BuildIdOutputVar;]$($QueuedBuild.id)"
        }
        Write-Host $($QueuedBuild.status)

--- a/azure-pipelines/scripts/queue-build.ps1
+++ b/azure-pipelines/scripts/queue-build.ps1
@@ -5,7 +5,7 @@ Param (
     [Parameter(Mandatory = $true)][String]$BuildDefinitionId,
     [Parameter(Mandatory = $false)][String]$PipelineVariablesJson,
     [Parameter(Mandatory = $false)][String]$Branch,
-    [Parameter(Mandatory = $false)][int]$WaitTimeoutInMinutes = 60,
+    [Parameter(Mandatory = $false)][int]$WaitTimeoutInMinutes = 80,
     [Parameter(Mandatory = $false)][int]$PollingIntervalInSeconds = 5 * 60
 )
 

--- a/azure-pipelines/scripts/queue-build.ps1
+++ b/azure-pipelines/scripts/queue-build.ps1
@@ -7,7 +7,7 @@ Param (
     [Parameter(Mandatory = $false)][String]$Branch,
     [Parameter(Mandatory = $false)][int]$WaitTimeoutInMinutes = 120,
     [Parameter(Mandatory = $false)][int]$PollingIntervalInSeconds = 5 * 60,
-    [Parameter(Mandatory = $false)][int]$BuildIdOutputVar=""
+    [Parameter(Mandatory = $false)][String]$BuildIdOutputVar=""
 )
 
 #request uri

--- a/azure-pipelines/scripts/queue-build.ps1
+++ b/azure-pipelines/scripts/queue-build.ps1
@@ -52,6 +52,9 @@ $BuildStartTime= Get-Date
 do{
    try {
        $QueuedBuild = Invoke-RestMethod -Uri $getBuildUri -Method Get -ContentType "application/json" -Headers $authHeader;
+       if($BuildIdOutputVar -ne $null) {
+            Write-Host "##vso[task.setvariable variable=$BuildIdOutputVar;]$($QueuedBuild.id)"
+       }
        Write-Host $($QueuedBuild.status)
        $BuildNotCompleted = ($($QueuedBuild.status) -eq "inProgress") -Or ($($QueuedBuild.status) -eq "notStarted")
        if($BuildNotCompleted){

--- a/azure-pipelines/scripts/queue-build.ps1
+++ b/azure-pipelines/scripts/queue-build.ps1
@@ -5,7 +5,7 @@ Param (
     [Parameter(Mandatory = $true)][String]$BuildDefinitionId,
     [Parameter(Mandatory = $false)][String]$PipelineVariablesJson,
     [Parameter(Mandatory = $false)][String]$Branch,
-    [Parameter(Mandatory = $false)][int]$WaitTimeoutInMinutes = 80,
+    [Parameter(Mandatory = $false)][int]$WaitTimeoutInMinutes = 120,
     [Parameter(Mandatory = $false)][int]$PollingIntervalInSeconds = 5 * 60
 )
 

--- a/azure-pipelines/scripts/queue-build.ps1
+++ b/azure-pipelines/scripts/queue-build.ps1
@@ -54,7 +54,9 @@ do{
    try {
        $QueuedBuild = Invoke-RestMethod -Uri $getBuildUri -Method Get -ContentType "application/json" -Headers $authHeader;
        if($BuildIdOutputVar -ne "") {
-            Write-Host "##vso[task.setvariable variable=$BuildIdOutputVar;]$($QueuedBuild.id)"
+            Write-Host "Setting  $BuildIdOutputVar"
+            Write-Host "##vso[task.setvariable variable=$($BuildIdOutputVar)]$($QueuedBuild.id)"
+            Write-Host "$BuildIdOutputVar = $($QueuedBuild.id)"
        }
        Write-Host $($QueuedBuild.status)
        $BuildNotCompleted = ($($QueuedBuild.status) -eq "inProgress") -Or ($($QueuedBuild.status) -eq "notStarted")


### PR DESCRIPTION
Making following enhancements to daily-release pipeline

- Added jobs to run and publish unit test results
- Added stage to automatically promote the published packages to release/prerelease views
- Added stage to generate CompanyPortal apk with daily builds
- Added task to import and publish the broker automation run result
- Added task to publish code coverage numbers
- Remove dependency on user PAT

TestRun: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1042260&view=results