### PR TITLE
Revert "Decreased powerlift version to 1.0.0"

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -65,7 +65,7 @@ ext {
     javaAssistVersion = "3.27.0-GA"
     yubikitAndroidVersion = "2.1.0"
     yubikitPivVersion = "2.1.0"
-    powerliftAndroidVersion="1.0.0"
+    powerliftAndroidVersion="1.0.1"
 
     // TODO: adal automation test app.
     supportLibraryVersion = "27.1.+"


### PR DESCRIPTION
Reverts AzureAD/android-complete#178

Company Portal has now fixed the issue and increased the powerlift version to 1.0.1. 
So, I am increasing the powerlift version in broker as well to 1.0.1