### PR TITLE
Improvements to release pipeline

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -170,3 +170,16 @@
             printf '\n' ; printf '%s' "3. LIST OF GENERATED BRANCHES"; printf '%s': "  "; \
             printf '\n' ; cd $workDir/; git droidShowBranches; \
         }; f"
+    droidCheckoutDev = "!f() { \
+              workDir=$(git config --get androidcomplete.workDir); \
+              cd $workDir/adal/; git checkout dev; git fetch; git pull;  git submodule update; \
+              cd $workDir/msal/; git checkout dev; git fetch; git pull;  git submodule update; \
+              cd $workDir/broker/; git checkout dev; git fetch; git pull;  git submodule update; \
+              cd $workDir/common/; git checkout dev; git fetch; git pull; \
+          }; f"
+    droidUpdateSubmodules = "!f() { \
+              workDir=$(git config --get androidcomplete.workDir); \
+              cd $workDir/adal/; git submodule update; \
+              cd $workDir/msal/; git submodule update; \
+              cd $workDir/broker/; git submodule update; \
+          }; f"

--- a/azure-pipelines/test-app/msal-test-app.yml
+++ b/azure-pipelines/test-app/msal-test-app.yml
@@ -44,6 +44,13 @@ resources:
     name: AzureAD/microsoft-authentication-library-for-android
     ref: dev
     endpoint: ANDROID_GITHUB
+    # We need broker to get otelexporter
+  - repository: broker
+    type: github
+    name: AzureAD/ad-accounts-for-android
+    ref: dev
+    endpoint: ANDROID_GITHUB
+
 
 jobs:
 - job: msal_test_app
@@ -59,6 +66,9 @@ jobs:
   - checkout: msal
     clean: true
     path: android-complete/msal
+  - checkout: broker
+    clean: true
+    path: android-complete/broker
   - checkout: common
     clean: true
     path: android-complete/common

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -239,7 +239,6 @@ stages:
 # Testing Libraries - KeyVault, LabApi, LabApiUtilities, TestUtils, UiAutomationUtilities
 - stage: 'publishCommonUtilities'
   displayName: Testing Libraries - Build and publish  
-  dependsOn: publishCommonLibraries
   condition: |
     and
     (

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -185,6 +185,27 @@ variables:
 
 stages:
 # Package generation
+# Testing Libraries - KeyVault, LabApi, LabApiUtilities, TestUtils, UiAutomationUtilities
+- stage: 'publishCommonUtilities'
+  displayName: Testing Libraries - Build and publish
+  dependsOn: [] # this removes the implicit dependency on previous stage and causes this to run in parallel
+  condition: |
+    and
+    (
+      not(failed()),
+      not(canceled()),
+      eq(${{ parameters.shouldBuildTestingLibraries }}, 'True')
+    )
+  jobs:
+    - job: queue_build
+      displayName: Update Testing libraries 
+      steps:
+        - task: PowerShell@2
+          displayName: Queue and wait for testing libraries 
+          inputs:
+            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
+            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$(System.AccessToken)" -BuildDefinitionId "1464"  -Branch "${{ parameters.commonVersionRC }}"'
+            workingDirectory: '$(Build.SourcesDirectory)'
 # Common4j - Build and publish
 - stage: 'publishCommon4jLibraries'
   displayName: Common4j - Build and publish
@@ -235,29 +256,6 @@ stages:
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
       shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
-
-# Testing Libraries - KeyVault, LabApi, LabApiUtilities, TestUtils, UiAutomationUtilities
-- stage: 'publishCommonUtilities'
-  displayName: Testing Libraries - Build and publish  
-  condition: |
-    and
-    (
-      not(failed()),
-      not(canceled()),
-      eq(${{ parameters.shouldBuildTestingLibraries }}, 'True')
-    )
-  jobs:
-    - job: queue_build
-      displayName: Update Testing libraries 
-      steps:
-        - task: PowerShell@2
-          displayName: Queue and wait for testing libraries 
-          inputs:
-            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$(System.AccessToken)" -BuildDefinitionId "1464"  -Branch "${{ parameters.commonVersionRC }}"'
-            workingDirectory: '$(Build.SourcesDirectory)'
-
-
 # Broker4j - Build and publish
 - stage: 'publishBroker4jLibraries'
   displayName: Broker4j - Build and publish  
@@ -296,6 +294,7 @@ stages:
   dependsOn: 
   - publishCommonLibraries
   - publishBroker4jLibraries
+  - publishCommonUtilities
   condition: |
     and
     (
@@ -322,7 +321,9 @@ stages:
 # Msal - Build and publish      
 - stage: 'publishMsal'
   displayName: Msal - Build and publish  
-  dependsOn: publishCommonLibraries
+  dependsOn: 
+  - publishCommonLibraries
+  - publishCommonUtilities
   condition: |
     and
     (

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -254,7 +254,7 @@ stages:
           displayName: Queue and wait for testing libraries 
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId "1464"  -Branch "${{ parameters.commonVersionRC }}"'
+            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$(System.AccessToken)" -BuildDefinitionId "1464"  -Branch "${{ parameters.commonVersionRC }}"'
             workingDirectory: '$(Build.SourcesDirectory)'
 
 

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -60,6 +60,10 @@ parameters:
   displayName: Run E2E UI Validation?
   type: boolean
   default: False
+- name: shouldBuildTestingLibraries
+  displayName: Build & Publish Testing libs?
+  type: boolean
+  default: False
 
 # Library versioning parameters
 - name: msalVersionRC
@@ -231,6 +235,30 @@ stages:
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
       shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
+
+# Testing Libraries - KeyVault, LabApi, LabApiUtilities, TestUtils, UiAutomationUtilities
+- stage: 'publishCommonUtilities'
+  displayName: Testing Libraries - Build and publish  
+  dependsOn: publishCommonLibraries
+  condition: |
+    and
+    (
+      not(failed()),
+      not(canceled()),
+      eq(${{ parameters.shouldBuildTestingLibraries }}, 'True')
+    )
+  jobs:
+    - job: queue_build
+      displayName: Update Testing libraries 
+      steps:
+        - task: PowerShell@2
+          displayName: Queue and wait for testing libraries 
+          inputs:
+            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
+            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId "1464"  -Branch "${{ parameters.commonVersionRC }}"'
+            workingDirectory: '$(Build.SourcesDirectory)'
+
+
 # Broker4j - Build and publish
 - stage: 'publishBroker4jLibraries'
   displayName: Broker4j - Build and publish  
@@ -389,6 +417,7 @@ stages:
   jobs:
     - job: queue_build
       displayName: Queue Build for Authenticator RC
+      timeoutInMinutes: 90
       steps:
         - checkout: self
           persistCredentials: True


### PR DESCRIPTION
- Added a git cmd to checkout dev in all the core projects (common, broker, msal, adal)
- Added a git cmd to update the submodules in all the core projects (broker, msal, adal)
- Fix msal test app pipeline. (otelexporter is in the broker so we need to checkout broker)
- Extended timeout on building Authenticator step for Release Pipeline
- Trigger common testing utilities on the Release pipeline