### PR TITLE
Add LTW build task and Downloading LTW package task to the test pipelines.

### DIFF
--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -333,11 +333,11 @@ stages:
         - checkout: self
           persistCredentials: True
         - task: PowerShell@2
-          displayName: Queue and wait for Company Portal Apk generation pipeline
+          displayName: Queue and wait for Link to Windows Apk generation pipeline
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://microsoft.visualstudio.com/" -Project "OS" -PipelinePAT "LTWBranch" -WaitTimeoutInMinutes 120 -BuildDefinitionId "44201" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(brokerVersionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "$(LTWBranch)"'
+            arguments: '-OrganizationUrl "https://microsoft.visualstudio.com/" -Project "OS" -PipelinePAT "OSPAT" -WaitTimeoutInMinutes 120 -BuildDefinitionId "44201" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(brokerVersionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "$(LTWBranch)"'
             workingDirectory: '$(Build.SourcesDirectory)'
         - task: PowerShell@2
           inputs:

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -321,6 +321,24 @@ stages:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
             arguments: '-OrganizationUrl "https://msazure.visualstudio.com/" -Project "Intune" -PipelinePAT "$(pipelinepat)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "237827" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(brokerVersionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "$(companyPortalBranch)"'
             workingDirectory: '$(Build.SourcesDirectory)'
+# BrokerApk - Link to Windows Queue pipeline
+- stage: 'queueLinkToWindowsPipeline'
+  displayName: Company Link To Windows Apk Generation
+  dependsOn: promotePackages
+  jobs:
+    - job: queue_build_LinkToWindows
+      displayName: Generate Link To Windows Apk
+      timeoutInMinutes: 120
+      steps:
+        - checkout: self
+          persistCredentials: True
+        - task: PowerShell@2
+          displayName: Queue and wait for Company Portal Apk generation pipeline
+          continueOnError: true
+          inputs:
+            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
+            arguments: '-OrganizationUrl "https://msazure.visualstudio.com/" -Project "os" -PipelinePAT "$(pipelinepat)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "44201" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(brokerVersionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "user/Millard/AuthBrokerPipeline"'
+            workingDirectory: '$(Build.SourcesDirectory)'
 
 # Broker - E2E Automation
 - stage: 'runBrokerE2EAutomation'

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -337,7 +337,7 @@ stages:
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://msazure.visualstudio.com/" -Project "os" -PipelinePAT "$(pipelinepat)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "44201" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(brokerVersionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "user/Millard/AuthBrokerPipeline"'
+            arguments: '-OrganizationUrl "https://microsoft.visualstudio.com/" -Project "OS" -PipelinePAT "$(pipelinepat)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "44201" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(brokerVersionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "user/Millard/AuthBrokerPipeline"'
             workingDirectory: '$(Build.SourcesDirectory)'
         - task: PowerShell@2
           inputs:

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -325,7 +325,7 @@ stages:
 - stage: 'queueLinkToWindowsPipeline'
   displayName: Link To Windows Apk Generation
   dependsOn: promotePackages
-  condition: eq(varialbes.LTWIntegrationEnabled, 'true')
+  condition: eq(variables['LTWIntegrationEnabled'], 'true')
   jobs:
     - job: queue_build_LinkToWindows
       displayName: Generate Link To Windows Apk

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -323,7 +323,7 @@ stages:
             workingDirectory: '$(Build.SourcesDirectory)'
 # BrokerApk - Link to Windows Queue pipeline
 - stage: 'queueLinkToWindowsPipeline'
-  displayName: Company Link To Windows Apk Generation
+  displayName: Link To Windows Apk Generation
   dependsOn: promotePackages
   jobs:
     - job: queue_build_LinkToWindows

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -325,6 +325,7 @@ stages:
 - stage: 'queueLinkToWindowsPipeline'
   displayName: Link To Windows Apk Generation
   dependsOn: promotePackages
+  condition: eq(varialbes.LTWIntegrationEnabled, 'true')
   jobs:
     - job: queue_build_LinkToWindows
       displayName: Generate Link To Windows Apk

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -339,13 +339,6 @@ stages:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
             arguments: '-OrganizationUrl "https://microsoft.visualstudio.com/" -Project "OS" -PipelinePAT "$(OSPAT)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "44201" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(brokerVersionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "$(LTWBranch)"'
             workingDirectory: '$(Build.SourcesDirectory)'
-        - task: PowerShell@2
-          inputs:
-            targetType: 'inline'
-            script: 
-              # Force fail for test
-              LASTEXITCODE = 100
-            workingDirectory: '$(Build.SourcesDirectory)'
 
 # Broker - E2E Automation
 - stage: 'runBrokerE2EAutomation'

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -339,6 +339,13 @@ stages:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
             arguments: '-OrganizationUrl "https://msazure.visualstudio.com/" -Project "os" -PipelinePAT "$(pipelinepat)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "44201" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(brokerVersionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "user/Millard/AuthBrokerPipeline"'
             workingDirectory: '$(Build.SourcesDirectory)'
+        - task: PowerShell@2
+          inputs:
+            targetType: 'inline'
+            script: 
+              # Force fail for test
+              LASTEXITCODE = 100
+            workingDirectory: '$(Build.SourcesDirectory)'
 
 # Broker - E2E Automation
 - stage: 'runBrokerE2EAutomation'

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -337,7 +337,7 @@ stages:
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://microsoft.visualstudio.com/" -Project "OS" -PipelinePAT "OSPAT" -WaitTimeoutInMinutes 120 -BuildDefinitionId "44201" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(brokerVersionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "$(LTWBranch)"'
+            arguments: '-OrganizationUrl "https://microsoft.visualstudio.com/" -Project "OS" -PipelinePAT "$(OSPAT)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "44201" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(brokerVersionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "$(LTWBranch)"'
             workingDirectory: '$(Build.SourcesDirectory)'
         - task: PowerShell@2
           inputs:

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -337,7 +337,7 @@ stages:
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://microsoft.visualstudio.com/" -Project "OS" -PipelinePAT "$(pipelinepat)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "44201" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(brokerVersionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "user/Millard/AuthBrokerPipeline"'
+            arguments: '-OrganizationUrl "https://microsoft.visualstudio.com/" -Project "OS" -PipelinePAT "LTWBranch" -WaitTimeoutInMinutes 120 -BuildDefinitionId "44201" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(brokerVersionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "$(LTWBranch)"'
             workingDirectory: '$(Build.SourcesDirectory)'
         - task: PowerShell@2
           inputs:

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -46,7 +46,7 @@ variables:
   edgeApk: Edge.apk
   firebaseTimeout: 45m
   resultsHistoryName: Broker Release
-  OSServiceConnection: AndroidBroker-CI
+  OSServiceConnection: https://microsoft.visualstudio.com/OS
   LTWFeedName: a4109c16-628c-42a8-9d6e-c2d9b870251a
   
 parameters:

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -151,11 +151,13 @@ stages:
         azureSamplePipelineId: '$(azureSamplePipelineId)'
         msazureServiceConnection: '$(msazureServiceConnection)'
         msazureFeedName: '$(msazureFeedName)'
+        LTWFeedName: '$(LTWFeedName)'
         authenticatorVersion: ${{ parameters.authenticatorVersion }}
         oldAuthenticatorVersion: ${{ parameters.oldAuthenticatorVersion }}
         companyPortalVersion: ${{ parameters.companyPortalVersion }}
         brokerHostPipelineId: '$(brokerHostPipelineId)'
         oldBrokerHostVersion: ${{ parameters.oldBrokerHostVersion }}
+        LTWVersion: ${{ parameters.LTWVersion }}
 # MSAL with Broker Test Plan stage (API 30+)
 - stage: 'msal_with_broker_high_api'
   dependsOn:

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -47,7 +47,7 @@ variables:
   firebaseTimeout: 45m
   resultsHistoryName: Broker Release
   OSServiceConnection: https://microsoft.visualstudio.com/OS
-  LTWFeedName: a4109c16-628c-42a8-9d6e-c2d9b870251a
+  LTWFeedName: Android-Auth-Broker-LTW-Build
   
 parameters:
 - name: firebaseDeviceIdHigh

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -46,7 +46,7 @@ variables:
   edgeApk: Edge.apk
   firebaseTimeout: 45m
   resultsHistoryName: Broker Release
-  LTWFeedName: Android-Auth-Broker-LTW-Build
+  LTWFeedName: a4109c16-628c-42a8-9d6e-c2d9b870251a
 parameters:
 - name: firebaseDeviceIdHigh
   displayName: Firebase Device Id (Api 30+)

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -48,6 +48,7 @@ variables:
   resultsHistoryName: Broker Release
   OSServiceConnection: LTW-Integration
   LTWFeedName: Auth-Broker-Integrated-LTW-Build
+  LTWApk: LTW-signed.apk
   
 parameters:
 - name: firebaseDeviceIdHigh
@@ -178,6 +179,7 @@ stages:
         resultsDir: "msalautomationapp-testpass-broker-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
         otherFiles: "/data/local/tmp/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
                       /data/local/tmp/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
+                      /data/local/tmp/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
                       /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
@@ -204,6 +206,7 @@ stages:
         resultsDir: "msalautomationapp-testpass-brokerhost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
         otherFiles: "/data/local/tmp/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
                       /data/local/tmp/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
+                      /data/local/tmp/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
                       /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
@@ -229,6 +232,7 @@ stages:
         resultsDir: "msalautomationapp-testpass-broker-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
         otherFiles: "/data/local/tmp/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
                       /data/local/tmp/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
+                      /data/local/tmp/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
                       /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
@@ -257,6 +261,7 @@ stages:
         resultsDir: "brokerautomationapp-testpass-adal&basic-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
         otherFiles: "/data/local/tmp/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
                       /data/local/tmp/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
+                      /data/local/tmp/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
                       /data/local/tmp/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /data/local/tmp/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -47,7 +47,7 @@ variables:
   firebaseTimeout: 45m
   resultsHistoryName: Broker Release
   OSServiceConnection: LTW-Integration
-  LTWFeedName: Android-Auth-Broker-LTW-Build
+  LTWFeedName: Auth-Broker-Integrated-LTW-Build
   
 parameters:
 - name: firebaseDeviceIdHigh

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -46,7 +46,7 @@ variables:
   edgeApk: Edge.apk
   firebaseTimeout: 45m
   resultsHistoryName: Broker Release
-  OSServiceConnection: https://microsoft.visualstudio.com/OS
+  OSServiceConnection: LTW-Integration
   LTWFeedName: Android-Auth-Broker-LTW-Build
   
 parameters:

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -46,7 +46,9 @@ variables:
   edgeApk: Edge.apk
   firebaseTimeout: 45m
   resultsHistoryName: Broker Release
+  OSServiceConnection: AndroidBroker-CI
   LTWFeedName: a4109c16-628c-42a8-9d6e-c2d9b870251a
+  
 parameters:
 - name: firebaseDeviceIdHigh
   displayName: Firebase Device Id (Api 30+)
@@ -151,6 +153,7 @@ stages:
         azureSamplePipelineId: '$(azureSamplePipelineId)'
         msazureServiceConnection: '$(msazureServiceConnection)'
         msazureFeedName: '$(msazureFeedName)'
+        OSServiceConnection: '$(OSServiceConnection)'
         LTWFeedName: '$(LTWFeedName)'
         authenticatorVersion: ${{ parameters.authenticatorVersion }}
         oldAuthenticatorVersion: ${{ parameters.oldAuthenticatorVersion }}

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -46,7 +46,7 @@ variables:
   edgeApk: Edge.apk
   firebaseTimeout: 45m
   resultsHistoryName: Broker Release
-
+  LTWFeedName: Android-Auth-Broker-LTW-Build
 parameters:
 - name: firebaseDeviceIdHigh
   displayName: Firebase Device Id (Api 30+)
@@ -84,6 +84,10 @@ parameters:
   displayName: Old Broker host Version
   type: string
   default: '0.0.1'
+- name: LTWVersion
+  displayName: Link to Windows Version
+  type: string
+  default: '*'
 - name: msalTestTarget
   displayName: Test Targets for MSAL
   type: string

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -26,6 +26,9 @@ parameters:
     default: 'AndroidAdal'
   - name: LTWFeedName
     type: string
+  - name: OSServiceConnection
+    displayName: Link to Windows Service Connection
+    type: string
   - name: LTWVersion
     displayName: Link to Windows Version
     type: string

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -32,6 +32,7 @@ parameters:
   - name: LTWVersion
     displayName: Link to Windows Version
     type: string
+    default: '*'
 jobs:
 - job: 'download_brokers'
   displayName: Download Brokers

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -92,6 +92,9 @@ jobs:
         feedDownloadExternal: '${{ parameters.LTWFeedName }}'
         packageDownloadExternal: 'com.microsoft.appmanager'
         versionDownloadExternal: '${{ parameters.LTWVersion }}'
+    - script: mv ./YPC-*.apk ./LTW-signed.apk
+      displayName: 'Rename LTW build to LTW-signed.apk'
+      workingDirectory: '$(Build.ArtifactStagingDirectory)/brokers'
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Broker Host'
       inputs:

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -24,7 +24,13 @@ parameters:
   - name: internalFeedName
     type: string
     default: 'AndroidAdal'
-
+  - name: OSServiceConnection
+    type: string
+  - name: LTWFeedName
+    type: string
+  - name: LTWVersion
+    displayName: Link to Windows Version
+    type: string
 jobs:
 - job: 'download_brokers'
   displayName: Download Brokers
@@ -74,6 +80,16 @@ jobs:
         feedDownloadExternal: '${{ parameters.msazureFeedName }}'
         packageDownloadExternal: 'com.microsoft.windowsintune.companyportal-signed'
         versionDownloadExternal: '${{ parameters.companyPortalVersion }}'
+    - task: UniversalPackages@0
+      displayName: 'Download com.microsoft.appmanager'
+      inputs:
+        command: 'download'
+        downloadDirectory: '$(Build.ArtifactStagingDirectory)/brokers'
+        feedsToUse: 'external'
+        externalFeedCredentials: '${{ parameters.OSServiceConnection }}'
+        feedDownloadExternal: '${{ parameters.LTWFeedName }}'
+        packageDownloadExternal: 'com.microsoft.appmanager'
+        versionDownloadExternal: '${{ parameters.LTWVersion }}'
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Broker Host'
       inputs:

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -24,8 +24,6 @@ parameters:
   - name: internalFeedName
     type: string
     default: 'AndroidAdal'
-  - name: OSServiceConnection
-    type: string
   - name: LTWFeedName
     type: string
   - name: LTWVersion
@@ -86,7 +84,7 @@ jobs:
         command: 'download'
         downloadDirectory: '$(Build.ArtifactStagingDirectory)/brokers'
         feedsToUse: 'external'
-        externalFeedCredentials: '${{ parameters.OSServiceConnection }}'
+        externalFeedCredentials: '${{ parameters.msazureServiceConnection }}'
         feedDownloadExternal: '${{ parameters.LTWFeedName }}'
         packageDownloadExternal: 'com.microsoft.appmanager'
         versionDownloadExternal: '${{ parameters.LTWVersion }}'

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -87,7 +87,7 @@ jobs:
         command: 'download'
         downloadDirectory: '$(Build.ArtifactStagingDirectory)/brokers'
         feedsToUse: 'external'
-        externalFeedCredentials: '${{ parameters.msazureServiceConnection }}'
+        externalFeedCredentials: '${{ parameters.OSServiceConnection }}'
         feedDownloadExternal: '${{ parameters.LTWFeedName }}'
         packageDownloadExternal: 'com.microsoft.appmanager'
         versionDownloadExternal: '${{ parameters.LTWVersion }}'


### PR DESCRIPTION
Tested with LTW build pipeline. The auth-client-android-dev pipeline can trigger the LTW build pipeline correctly and the Android Broker CI](https://identitydivision.visualstudio.com/Engineering/_build?definitionId=1490&_a=summary)
![image](https://user-images.githubusercontent.com/9159642/233535060-68ffc64e-0fd3-417d-96bb-e71768feba33.png)
