### PR TITLE
Fix Testing Libraries Build Stage in Release

### DIFF
--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -204,7 +204,7 @@ stages:
           displayName: Queue and wait for testing libraries 
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$(System.AccessToken)" -BuildDefinitionId "1464"  -Branch "${{ parameters.commonVersionRC }}"'
+            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$(System.AccessToken)" -BuildDefinitionId "1464"  -Branch "${{ parameters.commonBranch }}"'
             workingDirectory: '$(Build.SourcesDirectory)'
 # Common4j - Build and publish
 - stage: 'publishCommon4jLibraries'


### PR DESCRIPTION
We were passing common rc version as the branch name when building testing libraries. I changed this to use common branch parameter instead.