### PR TITLE
Fix the Linux broker testing job in the daily pipeline

### DIFF
--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -4,6 +4,7 @@
 parameters:
 - name: repository
 - name: project
+  type: string
 - name: assembleCmd
   default: assemble
 - name: testCmd
@@ -115,7 +116,7 @@ jobs:
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true
       inputs:
-        ${{ if eq('variables['parameters.project']', 'LinuxBroker') }}:
+        ${{ if eq(variables['parameters.project'], 'LinuxBroker') }}:
           tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.testParams}}
         ${{ else }}:
           tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.assembleParams}} -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -33,50 +33,6 @@ parameters:
   default: ''
   
 jobs:
-- job: publish${{ parameters.project }}Libraries
-  enabled: false
-  displayName: ${{ parameters.project }} build & publish
-  pool:
-    ${{ if eq(parameters.agentImage, 'none') }}:
-      vmImage: ubuntu-latest
-    ${{ else }}:
-      name: ${{ parameters.agentImage }}
-  variables:
-  - group: AndroidAuthClientVariables
-  steps:
-  - checkout: ${{ parameters.repository }}
-    persistCredentials: True
-  - task: Gradle@3
-    displayName: Build ${{ parameters.project }}
-    inputs:
-      tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.assembleParams}}
-    env:
-      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
-      ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
-  - task: Gradle@3
-    displayName: Generate Lockfile ${{ parameters.project }}
-    inputs:
-      tasks: -q ${{ parameters.project }}:dependencies ${{ parameters.dependencyParams }}
-    env:
-      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
-      ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
-  - task: Gradle@3
-    condition: |
-      and
-      (
-        not(failed()),
-        not(canceled()),
-        or( eq(${{ parameters.shouldPublish }}, 'True'), eq( variables['Build.Reason'], 'Schedule'))
-      )
-    displayName: Publish ${{ parameters.project }}
-    inputs:
-      tasks: ${{ parameters.project }}:${{ parameters.publishCmd}} ${{ parameters.publishParams}}
-    env:
-      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
-      ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
-  - task: ComponentGovernanceComponentDetection@0
-    inputs:
-      sourceScanPath: $(Build.SourcesDirectory)/${{ parameters.project }}/gradle/dependency-locks/
 - job: RunUnitTest${{ parameters.project }}
   displayName: ${{ parameters.project }} UnitTest
   pool:

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -115,7 +115,7 @@ jobs:
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true
       inputs:
-        ${{ if eq(variables['parameters.project'], 'LinuxBroker') }}:
+        ${{ if eq('variables['parameters.project']', 'LinuxBroker') }}:
           tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.testParams}}
         ${{ else }}:
           tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.assembleParams}} -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -29,7 +29,7 @@ parameters:
 - name: shouldRunLinuxInlineScript
   type: boolean
   default: False
-- name: linuxParams
+- name: testParams
   default: ''
   
 jobs:
@@ -54,7 +54,6 @@ jobs:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
   - task: Gradle@3
-    enabled: false
     displayName: Generate Lockfile ${{ parameters.project }}
     inputs:
       tasks: -q ${{ parameters.project }}:dependencies ${{ parameters.dependencyParams }}
@@ -70,14 +69,12 @@ jobs:
         or( eq(${{ parameters.shouldPublish }}, 'True'), eq( variables['Build.Reason'], 'Schedule'))
       )
     displayName: Publish ${{ parameters.project }}
-    enabled: false
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.publishCmd}} ${{ parameters.publishParams}}
     env:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
   - task: ComponentGovernanceComponentDetection@0
-    enabled: false
     inputs:
       sourceScanPath: $(Build.SourcesDirectory)/${{ parameters.project }}/gradle/dependency-locks/
 - job: RunUnitTest${{ parameters.project }}
@@ -114,17 +111,12 @@ jobs:
           eval $(dbus-launch --sh-syntax)
           sudo apt install gnome-keyring
           /usr/bin/gnome-keyring-daemon --start --components=secrets
-          ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PdistCommon4jVersion=0.0.20230517-dev.8 -PdistBroker4jVersion=0.0.20230517-dev.8 -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
-      env:
-        ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
-        ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
     - task: Gradle@3
-      condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'False')
       displayName: Run Test ${{ parameters.project }}
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true
       inputs:
-        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} -PdistCommon4jVersion=0.0.20230517-dev.8 -PdistBroker4jVersion=0.0.20230517-dev.8 -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
+        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.testParams}}
         testRunTitle: '${{ parameters.project }}_UnitTests'
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -91,7 +91,7 @@ jobs:
         SecretsFilter: 'AndroidAutomationRunnerAppSecret'
         RunAsPreJob: false
     - task: Bash@3
-      condition: ne(${{ parameters.shouldRunLinuxInlineScript }}, 'False')
+      condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'True')
       retryCountOnTaskFailure: 3
       displayName: Linux Testing Setup
       inputs:

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -108,7 +108,9 @@ jobs:
           eval $(dbus-launch --sh-syntax)
           sudo apt install gnome-keyring
           /usr/bin/gnome-keyring-daemon --start --components=secrets
+          ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
     - task: Gradle@3
+      condition: neq(${{ parameters.shouldRunLinuxInlineScript }}, 'True')
       displayName: Run Test ${{ parameters.project }}
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -47,6 +47,7 @@ jobs:
     persistCredentials: True
   - task: Gradle@3
     displayName: Build ${{ parameters.project }}
+    enabled: false
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.assembleParams}}
     env:
@@ -113,6 +114,9 @@ jobs:
           sudo apt install gnome-keyring
           /usr/bin/gnome-keyring-daemon --start --components=secrets
           ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
+      env:
+        ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
+        ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
     - task: Gradle@3
       condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'False')
       displayName: Run Test ${{ parameters.project }}

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -29,7 +29,9 @@ parameters:
 - name: shouldRunLinuxInlineScript
   type: boolean
   default: False
-
+- name: linuxParams
+  default: ''
+  
 jobs:
 - job: publish${{ parameters.project }}Libraries
   displayName: ${{ parameters.project }} build & publish
@@ -111,7 +113,7 @@ jobs:
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true
       inputs:
-        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.assembleParams}} -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
+        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.assembleParams}} -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true ${{ parameters.linuxParams}}
         testRunTitle: '${{ parameters.project }}_UnitTests'
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -115,7 +115,7 @@ jobs:
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true
       inputs:
-        ${{ if eq(${{ parameters.project }}, 'LinuxBroker') }}:
+        ${{ if eq(parameters.project, 'LinuxBroker') }}:
           tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.testParams}}
         ${{ else }}:
           tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.assembleParams}} -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -125,7 +125,7 @@ jobs:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
         ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
     - task: Gradle@3
-      condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'False')
+      condition: ne(${{ parameters.shouldRunLinuxInlineScript }}, 'True')
       displayName: Run Test ${{ parameters.project }}
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -34,7 +34,7 @@ parameters:
   
 jobs:
 - job: publish${{ parameters.project }}Libraries
-  condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'abc')
+  condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'False')
   displayName: ${{ parameters.project }} build & publish
   pool:
     ${{ if eq(parameters.agentImage, 'none') }}:

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -35,7 +35,6 @@ parameters:
 jobs:
 - job: publish${{ parameters.project }}Libraries
   condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'abc')
-  enabled: false
   displayName: ${{ parameters.project }} build & publish
   pool:
     ${{ if eq(parameters.agentImage, 'none') }}:

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -92,20 +92,20 @@ jobs:
         RunAsPreJob: false
     - task: Bash@3
       condition: ne(${{ parameters.shouldRunLinuxInlineScript }}, 'False')
-        retryCountOnTaskFailure: 3
-        displayName: Linux Testing Setup
-        inputs:
-          workingDirectory: $(Build.SourcesDirectory)/broker-java-root
-          targetType: 'inline'
-          script: |
-            sudo apt-get install -y dbus-x11
-            sudo apt-get install -y dos2unix
-            dos2unix gradlew
-            chmod +x gradlew
-            export DISPLAY=:0.0
-            eval $(dbus-launch --sh-syntax)
-            sudo apt install gnome-keyring
-            /usr/bin/gnome-keyring-daemon --start --components=secrets
+      retryCountOnTaskFailure: 3
+      displayName: Linux Testing Setup
+      inputs:
+        workingDirectory: $(Build.SourcesDirectory)/broker-java-root
+        targetType: 'inline'
+        script: |
+          sudo apt-get install -y dbus-x11
+          sudo apt-get install -y dos2unix
+          dos2unix gradlew
+          chmod +x gradlew
+          export DISPLAY=:0.0
+          eval $(dbus-launch --sh-syntax)
+          sudo apt install gnome-keyring
+          /usr/bin/gnome-keyring-daemon --start --components=secrets
     - task: Gradle@3
       displayName: Run Test ${{ parameters.project }}
       enabled: ${{ parameters.shouldRunUnitTests }}

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -28,7 +28,7 @@ parameters:
   type: boolean
   default: True
 - name: testParams
-  default: ''
+  default: ' ${{ parameters.assembleParams}} -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true'
   
 jobs:
 - job: publish${{ parameters.project }}Libraries
@@ -116,10 +116,7 @@ jobs:
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true
       inputs:
-        ${{ if eq(variables['parameters.project'], 'LinuxBroker') }}:
-          tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.testParams}}
-        ${{ else }}:
-          tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.assembleParams}} -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
+        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.testParams}}
         testRunTitle: '${{ parameters.project }}_UnitTests'
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -91,7 +91,8 @@ jobs:
         SecretsFilter: 'AndroidAutomationRunnerAppSecret'
         RunAsPreJob: false
     - task: Bash@3
-      condition: ne(shouldRunLinuxInlineScript,false)
+      condition: ne(${{ parameters.shouldRunLinuxInlineScript }}, 'False')
+        retryCountOnTaskFailure: 3
         displayName: Linux Testing Setup
         inputs:
           workingDirectory: $(Build.SourcesDirectory)/broker-java-root

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -46,7 +46,6 @@ jobs:
   - checkout: ${{ parameters.repository }}
     persistCredentials: True
   - task: Gradle@3
-    enabled: false
     displayName: Build ${{ parameters.project }}
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.assembleParams}}

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -34,6 +34,7 @@ parameters:
   
 jobs:
 - job: publish${{ parameters.project }}Libraries
+  enabled: false
   displayName: ${{ parameters.project }} build & publish
   pool:
     ${{ if eq(parameters.agentImage, 'none') }}:

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -109,6 +109,7 @@ jobs:
           eval $(dbus-launch --sh-syntax)
           sudo apt install gnome-keyring
           /usr/bin/gnome-keyring-daemon --start --components=secrets
+          ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
     - task: Gradle@3
       condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'True')
       displayName: Run Test ${{ parameters.project }}

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -33,6 +33,51 @@ parameters:
   default: ''
   
 jobs:
+- job: publish${{ parameters.project }}Libraries
+  condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'abc')
+  enabled: false
+  displayName: ${{ parameters.project }} build & publish
+  pool:
+    ${{ if eq(parameters.agentImage, 'none') }}:
+      vmImage: ubuntu-latest
+    ${{ else }}:
+      name: ${{ parameters.agentImage }}
+  variables:
+  - group: AndroidAuthClientVariables
+  steps:
+  - checkout: ${{ parameters.repository }}
+    persistCredentials: True
+  - task: Gradle@3
+    displayName: Build ${{ parameters.project }}
+    inputs:
+      tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.assembleParams}}
+    env:
+      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
+      ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
+  - task: Gradle@3
+    displayName: Generate Lockfile ${{ parameters.project }}
+    inputs:
+      tasks: -q ${{ parameters.project }}:dependencies ${{ parameters.dependencyParams }}
+    env:
+      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
+      ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
+  - task: Gradle@3
+    condition: |
+      and
+      (
+        not(failed()),
+        not(canceled()),
+        or( eq(${{ parameters.shouldPublish }}, 'True'), eq( variables['Build.Reason'], 'Schedule'))
+      )
+    displayName: Publish ${{ parameters.project }}
+    inputs:
+      tasks: ${{ parameters.project }}:${{ parameters.publishCmd}} ${{ parameters.publishParams}}
+    env:
+      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
+      ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
+  - task: ComponentGovernanceComponentDetection@0
+    inputs:
+      sourceScanPath: $(Build.SourcesDirectory)/${{ parameters.project }}/gradle/dependency-locks/
 - job: RunUnitTest${{ parameters.project }}
   displayName: ${{ parameters.project }} UnitTest
   pool:

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -114,23 +114,15 @@ jobs:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
         ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
     - task: Gradle@3
-      condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'True')
-      displayName: Run Test ${{ parameters.project }}
-      enabled: ${{ parameters.shouldRunUnitTests }}
-      continueOnError: true
-      inputs:
-        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.testParams}}
-        testRunTitle: '${{ parameters.project }}_UnitTests'
-      env:
-        ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
-        ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
-    - task: Gradle@3
       condition: ne(${{ parameters.shouldRunLinuxInlineScript }}, 'True')
       displayName: Run Test ${{ parameters.project }}
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true
       inputs:
-        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.assembleParams}} -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
+        ${{ if eq(${{ parameters.shouldRunLinuxInlineScript }}, 'True') }}:
+          tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.testParams}}
+        ${{ else }}:
+          tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.assembleParams}} -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
         testRunTitle: '${{ parameters.project }}_UnitTests'
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -123,7 +123,7 @@ jobs:
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true
       inputs:
-        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.assembleParams}} -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true ${{ parameters.linuxParams}}
+        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} -PdistCommon4jVersion="0.0.+" -PdistBroker4jVersion="0.0.+" -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
         testRunTitle: '${{ parameters.project }}_UnitTests'
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -4,7 +4,6 @@
 parameters:
 - name: repository
 - name: project
-  type: string
 - name: assembleCmd
   default: assemble
 - name: testCmd

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -26,9 +26,6 @@ parameters:
 - name: shouldRunUnitTests
   type: boolean
   default: True
-- name: shouldRunLinuxInlineScript
-  type: boolean
-  default: False
 - name: testParams
   default: ''
   
@@ -93,7 +90,7 @@ jobs:
         SecretsFilter: 'AndroidAutomationRunnerAppSecret'
         RunAsPreJob: false
     - task: Bash@3
-      condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'True')
+      condition: eq(${{ parameters.project }}, 'LinuxBroker')
       retryCountOnTaskFailure: 3
       displayName: Linux Testing Setup
       continueOnError: true
@@ -114,12 +111,11 @@ jobs:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
         ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
     - task: Gradle@3
-      condition: ne(${{ parameters.shouldRunLinuxInlineScript }}, 'True')
       displayName: Run Test ${{ parameters.project }}
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true
       inputs:
-        ${{ if eq(${{ parameters.shouldRunLinuxInlineScript }}, 'True') }}:
+        ${{ if eq(${{ parameters.project }}, 'LinuxBroker') }}:
           tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.testParams}}
         ${{ else }}:
           tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.assembleParams}} -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -110,6 +110,9 @@ jobs:
           sudo apt install gnome-keyring
           /usr/bin/gnome-keyring-daemon --start --components=secrets
           ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
+       env:
+        ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
+        ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
     - task: Gradle@3
       condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'True')
       displayName: Run Test ${{ parameters.project }}

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -101,6 +101,7 @@ jobs:
       condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'True')
       retryCountOnTaskFailure: 3
       displayName: Linux Testing Setup
+      continueOnError: true
       inputs:
         workingDirectory: $(Build.SourcesDirectory)/broker-java-root
         targetType: 'inline'

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -47,7 +47,6 @@ jobs:
     persistCredentials: True
   - task: Gradle@3
     displayName: Build ${{ parameters.project }}
-    enabled: false
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.assembleParams}}
     env:
@@ -88,7 +87,6 @@ jobs:
       persistCredentials: True
     - task: AzureKeyVault@2
       displayName: 'Get Key vault AndroidAutomationRunnerAppSecret'
-      enabled: false
       inputs:
         azureSubscription: 'MSIDLABS_ANDROID_KV'
         KeyVaultName: 'ADALTestInfo'

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -111,7 +111,7 @@ jobs:
           /usr/bin/gnome-keyring-daemon --start --components=secrets
           ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
     - task: Gradle@3
-      condition: neq(${{ parameters.shouldRunLinuxInlineScript }}, 'True')
+      condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'False')
       displayName: Run Test ${{ parameters.project }}
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -26,6 +26,9 @@ parameters:
 - name: shouldRunUnitTests
   type: boolean
   default: True
+- name: shouldRunLinuxInlineScript
+  type: boolean
+  default: False
 
 jobs:
 - job: publish${{ parameters.project }}Libraries
@@ -87,6 +90,22 @@ jobs:
         KeyVaultName: 'ADALTestInfo'
         SecretsFilter: 'AndroidAutomationRunnerAppSecret'
         RunAsPreJob: false
+    - task: Bash@3
+      condition: ne(shouldRunLinuxInlineScript,false)
+        retryCountOnTaskFailure: 3
+        displayName: Linux Testing Setup
+        inputs:
+          workingDirectory: $(Build.SourcesDirectory)/broker-java-root
+          targetType: 'inline'
+          script: |
+            sudo apt-get install -y dbus-x11
+            sudo apt-get install -y dos2unix
+            dos2unix gradlew
+            chmod +x gradlew
+            export DISPLAY=:0.0
+            eval $(dbus-launch --sh-syntax)
+            sudo apt install gnome-keyring
+            /usr/bin/gnome-keyring-daemon --start --components=secrets
     - task: Gradle@3
       displayName: Run Test ${{ parameters.project }}
       enabled: ${{ parameters.shouldRunUnitTests }}

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -110,9 +110,9 @@ jobs:
           sudo apt install gnome-keyring
           /usr/bin/gnome-keyring-daemon --start --components=secrets
           ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
-     env:
-      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
-      ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
+      env:
+        ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
+        ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
     - task: Gradle@3
       condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'True')
       displayName: Run Test ${{ parameters.project }}

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -114,7 +114,7 @@ jobs:
           eval $(dbus-launch --sh-syntax)
           sudo apt install gnome-keyring
           /usr/bin/gnome-keyring-daemon --start --components=secrets
-          ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PdistCommon4jVersion="0.0.+" -PdistBroker4jVersion="0.0.+" -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
+          ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PdistCommon4jVersion=0.0.+ -PdistBroker4jVersion=0.0.+ -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
         ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -124,7 +124,7 @@ jobs:
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true
       inputs:
-        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} -PdistCommon4jVersion="0.0.+" -PdistBroker4jVersion="0.0.+" -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
+        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} -PdistCommon4jVersion=0.0.+ -PdistBroker4jVersion=0.0.+ -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
         testRunTitle: '${{ parameters.project }}_UnitTests'
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -46,6 +46,7 @@ jobs:
   - checkout: ${{ parameters.repository }}
     persistCredentials: True
   - task: Gradle@3
+    enabled: false
     displayName: Build ${{ parameters.project }}
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.assembleCmd}} ${{ parameters.assembleParams}}
@@ -53,6 +54,7 @@ jobs:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
   - task: Gradle@3
+    enabled: false
     displayName: Generate Lockfile ${{ parameters.project }}
     inputs:
       tasks: -q ${{ parameters.project }}:dependencies ${{ parameters.dependencyParams }}
@@ -68,12 +70,14 @@ jobs:
         or( eq(${{ parameters.shouldPublish }}, 'True'), eq( variables['Build.Reason'], 'Schedule'))
       )
     displayName: Publish ${{ parameters.project }}
+    enabled: false
     inputs:
       tasks: ${{ parameters.project }}:${{ parameters.publishCmd}} ${{ parameters.publishParams}}
     env:
       ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
       ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
   - task: ComponentGovernanceComponentDetection@0
+    enabled: false
     inputs:
       sourceScanPath: $(Build.SourcesDirectory)/${{ parameters.project }}/gradle/dependency-locks/
 - job: RunUnitTest${{ parameters.project }}
@@ -87,6 +91,7 @@ jobs:
       persistCredentials: True
     - task: AzureKeyVault@2
       displayName: 'Get Key vault AndroidAutomationRunnerAppSecret'
+      enabled: false
       inputs:
         azureSubscription: 'MSIDLABS_ANDROID_KV'
         KeyVaultName: 'ADALTestInfo'

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -28,7 +28,7 @@ parameters:
   type: boolean
   default: True
 - name: testParams
-  default: ' ${{ parameters.assembleParams}} -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true'
+  default: ''
   
 jobs:
 - job: publish${{ parameters.project }}Libraries

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -115,7 +115,7 @@ jobs:
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true
       inputs:
-        ${{ if eq(parameters.project, 'LinuxBroker') }}:
+        ${{ if eq(variables['parameters.project'], 'LinuxBroker') }}:
           tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.testParams}}
         ${{ else }}:
           tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.assembleParams}} -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -110,9 +110,9 @@ jobs:
           sudo apt install gnome-keyring
           /usr/bin/gnome-keyring-daemon --start --components=secrets
           ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
-       env:
-        ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
-        ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
+     env:
+      ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
+      ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
     - task: Gradle@3
       condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'True')
       displayName: Run Test ${{ parameters.project }}

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -91,7 +91,7 @@ jobs:
         SecretsFilter: 'AndroidAutomationRunnerAppSecret'
         RunAsPreJob: false
     - task: Bash@3
-      condition: eq(${{ parameters.project }}, 'LinuxBroker')
+      condition: eq(variables['parameters.project'], 'LinuxBroker')
       retryCountOnTaskFailure: 3
       displayName: Linux Testing Setup
       continueOnError: true

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -114,7 +114,7 @@ jobs:
           eval $(dbus-launch --sh-syntax)
           sudo apt install gnome-keyring
           /usr/bin/gnome-keyring-daemon --start --components=secrets
-          ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PdistCommon4jVersion=0.0.+ -PdistBroker4jVersion=0.0.+ -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
+          ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PdistCommon4jVersion=0.0.20230517-dev.8 -PdistBroker4jVersion=0.0.20230517-dev.8 -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
         ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
@@ -124,7 +124,7 @@ jobs:
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true
       inputs:
-        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} -PdistCommon4jVersion=0.0.+ -PdistBroker4jVersion=0.0.+ -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
+        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} -PdistCommon4jVersion=0.0.20230517-dev.8 -PdistBroker4jVersion=0.0.20230517-dev.8 -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
         testRunTitle: '${{ parameters.project }}_UnitTests'
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -109,7 +109,7 @@ jobs:
           eval $(dbus-launch --sh-syntax)
           sudo apt install gnome-keyring
           /usr/bin/gnome-keyring-daemon --start --components=secrets
-          ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
+          ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport ${{ parameters.testParams}}
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
         ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -113,7 +113,7 @@ jobs:
           eval $(dbus-launch --sh-syntax)
           sudo apt install gnome-keyring
           /usr/bin/gnome-keyring-daemon --start --components=secrets
-          ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
+          ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -PdistCommon4jVersion="0.0.+" -PdistBroker4jVersion="0.0.+" -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
         ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -92,7 +92,6 @@ jobs:
         RunAsPreJob: false
     - task: Bash@3
       condition: ne(shouldRunLinuxInlineScript,false)
-        retryCountOnTaskFailure: 3
         displayName: Linux Testing Setup
         inputs:
           workingDirectory: $(Build.SourcesDirectory)/broker-java-root

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -110,11 +110,23 @@ jobs:
           sudo apt install gnome-keyring
           /usr/bin/gnome-keyring-daemon --start --components=secrets
     - task: Gradle@3
+      condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'True')
       displayName: Run Test ${{ parameters.project }}
       enabled: ${{ parameters.shouldRunUnitTests }}
       continueOnError: true
       inputs:
         tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.testParams}}
+        testRunTitle: '${{ parameters.project }}_UnitTests'
+      env:
+        ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)
+        ${{ parameters.vstsMvnAndroidAccessToken }}: $(System.AccessToken)
+    - task: Gradle@3
+      condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'False')
+      displayName: Run Test ${{ parameters.project }}
+      enabled: ${{ parameters.shouldRunUnitTests }}
+      continueOnError: true
+      inputs:
+        tasks: ${{ parameters.project }}:${{ parameters.testCmd}} ${{ parameters.assembleParams}} -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
         testRunTitle: '${{ parameters.project }}_UnitTests'
       env:
         ${{ parameters.vstsMvnAndroidUsername }}: $(AndroidAuthClient-Internal-Maven-Username)

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -34,7 +34,6 @@ parameters:
   
 jobs:
 - job: publish${{ parameters.project }}Libraries
-  condition: eq(${{ parameters.shouldRunLinuxInlineScript }}, 'False')
   displayName: ${{ parameters.project }} build & publish
   pool:
     ${{ if eq(parameters.agentImage, 'none') }}:

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -90,7 +90,7 @@ jobs:
         SecretsFilter: 'AndroidAutomationRunnerAppSecret'
         RunAsPreJob: false
     - task: Bash@3
-      condition: eq(variables['parameters.project'], 'LinuxBroker')
+      condition: eq('${{ parameters.project }}', 'LinuxBroker')
       retryCountOnTaskFailure: 3
       displayName: Linux Testing Setup
       continueOnError: true

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -167,6 +167,7 @@ stages:
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
+      shouldRunLinuxInlineScript: True
   - job: PublishLinuxBrokerPackage
     dependsOn: publishLinuxBrokerLibraries
     displayName: Publish Linux Broker Package

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -170,39 +170,39 @@ stages:
       linuxParams: -Psystemd_mode_enabled=false --build-cache --info
       shouldRunLinuxInlineScript: True
       shouldRunUnitTests: False
-  - job: PublishLinuxBrokerPackage
-    dependsOn: publishLinuxBrokerLibraries
-    displayName: Publish Linux Broker Package
-    pool:
-      vmImage: ubuntu-latest
-    variables:
-    - group: AndroidAuthClientVariables
-    steps:
-    - checkout: broker
-      persistCredentials: True
-    - task: Gradle@3
-      displayName: Build and publish linux broker package
-      env:
-        ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(AndroidAuthClient-Internal-Maven-Username)
-        ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(System.AccessToken)
-      inputs:
-        cwd: $(Build.SourcesDirectory)/broker-java-root
-        tasks: LinuxBrokerPackage:clean LinuxBrokerPackage:buildDeb $(linuxBrokerVersion) --build-cache --info
-        publishJUnitResults: false
-        jdkArchitecture: x86
-        sqAnalysisBreakBuildIfQualityGateFailed: false
-    - task: CopyFiles@2
-      name: CopyFiles1
-      displayName: Copy Files to Artifact Staging Directory
-      inputs:
-        SourceFolder: LinuxBrokerPackage/build/distributions
-        TargetFolder: $(build.artifactstagingdirectory)
-    - task: PublishPipelineArtifact@1
-      name: PublishPipelineArtifacts1
-      displayName: 'Publish Artifact: LinuxBrokerPackage Linux Test App Deb'
-      inputs:
-        ArtifactName: LinuxBrokerPackage Deb Package
-        TargetPath: $(build.artifactstagingdirectory)
+#  - job: PublishLinuxBrokerPackage
+#    dependsOn: publishLinuxBrokerLibraries
+#    displayName: Publish Linux Broker Package
+#    pool:
+#      vmImage: ubuntu-latest
+#    variables:
+#    - group: AndroidAuthClientVariables
+#    steps:
+#    - checkout: broker
+#      persistCredentials: True
+#    - task: Gradle@3
+#      displayName: Build and publish linux broker package
+#      env:
+#        ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(AndroidAuthClient-Internal-Maven-Username)
+#        ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(System.AccessToken)
+#      inputs:
+#        cwd: $(Build.SourcesDirectory)/broker-java-root
+#        tasks: LinuxBrokerPackage:clean LinuxBrokerPackage:buildDeb $(linuxBrokerVersion) --build-cache --info
+#        publishJUnitResults: false
+#        jdkArchitecture: x86
+#        sqAnalysisBreakBuildIfQualityGateFailed: false
+#    - task: CopyFiles@2
+#      name: CopyFiles1
+#      displayName: Copy Files to Artifact Staging Directory
+#      inputs:
+#        SourceFolder: LinuxBrokerPackage/build/distributions
+#        TargetFolder: $(build.artifactstagingdirectory)
+#    - task: PublishPipelineArtifact@1
+#      name: PublishPipelineArtifacts1
+#      displayName: 'Publish Artifact: LinuxBrokerPackage Linux Test App Deb'
+#      inputs:
+#        ArtifactName: LinuxBrokerPackage Deb Package
+#        TargetPath: $(build.artifactstagingdirectory)
 # Msal - Build and publish      
 - stage: 'publishMsal'
   displayName: Msal - Build and publish

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -169,6 +169,7 @@ stages:
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
       linuxParams: -Psystemd_mode_enabled=false --build-cache --info
       shouldRunLinuxInlineScript: True
+      shouldRunUnitTests: False
   - job: PublishLinuxBrokerPackage
     dependsOn: publishLinuxBrokerLibraries
     displayName: Publish Linux Broker Package

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -169,7 +169,6 @@ stages:
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
       linuxParams: -Psystemd_mode_enabled=false --build-cache --info
       shouldRunLinuxInlineScript: True
-      shouldRunUnitTests: False
 #  - job: PublishLinuxBrokerPackage
 #    dependsOn: publishLinuxBrokerLibraries
 #    displayName: Publish Linux Broker Package

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -83,6 +83,7 @@ stages:
       testCmd: common4jUnitTestCoverageReport
       dependencyParams: $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam)
+      testParams: $(projVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
       publishParams: $(projVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
@@ -101,6 +102,7 @@ stages:
       publishCmd: publishDistReleasePublicationToVsts-maven-adal-androidRepository
       dependencyParams:  $(common4jVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam)
+      testParams: $(projVersionParam) $(common4jVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
       publishParams: $(projVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
@@ -119,6 +121,7 @@ stages:
       publishCmd: publishAarPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(common4jVersionParam) $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam)
+      testParams: $(projVersionParam) $(common4jVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
       publishParams: $(projVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
@@ -143,6 +146,7 @@ stages:
       publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: -PprojVersion=$(brokerVersionNumber) $(broker4jVersionParam) $(commonVersionParam) $(powerLiftApiKeyParam)
+      testParams: PprojVersion=$(brokerVersionNumber) $(broker4jVersionParam) $(commonVersionParam) $(powerLiftApiKeyParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
       publishParams: -PprojVersion=$(brokerVersionNumber) $(broker4jVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
@@ -163,6 +167,7 @@ stages:
       testCmd: linuxBrokerUnitTestCoverageReport
       dependencyParams: $(broker4jVersionParam) $(common4jVersionParam) $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
+      testParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
       publishParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
@@ -215,6 +220,7 @@ stages:
       publishCmd: publishMsalPublicationToVsts-maven-adal-androidRepository 
       dependencyParams: $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(commonVersionParam)
+      testParams: $(projVersionParam) $(commonVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
       publishParams: $(projVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROID_MSAL_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN
@@ -233,6 +239,7 @@ stages:
       publishCmd: publishAdalPublicationToVsts-maven-adal-androidRepository 
       dependencyParams: $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(commonVersionParam)
+      testParams: $(projVersionParam) $(commonVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
       publishParams: $(projVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADAL_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -146,7 +146,7 @@ stages:
       publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: -PprojVersion=$(brokerVersionNumber) $(broker4jVersionParam) $(commonVersionParam) $(powerLiftApiKeyParam)
-      testParams: PprojVersion=$(brokerVersionNumber) $(broker4jVersionParam) $(commonVersionParam) $(powerLiftApiKeyParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
+      testParams: -PprojVersion=$(brokerVersionNumber) $(broker4jVersionParam) $(commonVersionParam) $(powerLiftApiKeyParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
       publishParams: -PprojVersion=$(brokerVersionNumber) $(broker4jVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -167,41 +167,41 @@ stages:
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
-      linuxParams: -Psystemd_mode_enabled=false --build-cache --info
+      testParams: $(broker4jVersionParam) $(common4jVersionParam) -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
       shouldRunLinuxInlineScript: True
-#  - job: PublishLinuxBrokerPackage
-#    dependsOn: publishLinuxBrokerLibraries
-#    displayName: Publish Linux Broker Package
-#    pool:
-#      vmImage: ubuntu-latest
-#    variables:
-#    - group: AndroidAuthClientVariables
-#    steps:
-#    - checkout: broker
-#      persistCredentials: True
-#    - task: Gradle@3
-#      displayName: Build and publish linux broker package
-#      env:
-#        ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(AndroidAuthClient-Internal-Maven-Username)
-#        ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(System.AccessToken)
-#      inputs:
-#        cwd: $(Build.SourcesDirectory)/broker-java-root
-#        tasks: LinuxBrokerPackage:clean LinuxBrokerPackage:buildDeb $(linuxBrokerVersion) --build-cache --info
-#        publishJUnitResults: false
-#        jdkArchitecture: x86
-#        sqAnalysisBreakBuildIfQualityGateFailed: false
-#    - task: CopyFiles@2
-#      name: CopyFiles1
-#      displayName: Copy Files to Artifact Staging Directory
-#      inputs:
-#        SourceFolder: LinuxBrokerPackage/build/distributions
-#        TargetFolder: $(build.artifactstagingdirectory)
-#    - task: PublishPipelineArtifact@1
-#      name: PublishPipelineArtifacts1
-#      displayName: 'Publish Artifact: LinuxBrokerPackage Linux Test App Deb'
-#      inputs:
-#        ArtifactName: LinuxBrokerPackage Deb Package
-#        TargetPath: $(build.artifactstagingdirectory)
+  - job: PublishLinuxBrokerPackage
+    dependsOn: publishLinuxBrokerLibraries
+    displayName: Publish Linux Broker Package
+    pool:
+      vmImage: ubuntu-latest
+    variables:
+    - group: AndroidAuthClientVariables
+    steps:
+    - checkout: broker
+      persistCredentials: True
+    - task: Gradle@3
+      displayName: Build and publish linux broker package
+      env:
+        ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME: $(AndroidAuthClient-Internal-Maven-Username)
+        ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN: $(System.AccessToken)
+      inputs:
+        cwd: $(Build.SourcesDirectory)/broker-java-root
+        tasks: LinuxBrokerPackage:clean LinuxBrokerPackage:buildDeb $(linuxBrokerVersion) --build-cache --info
+        publishJUnitResults: false
+        jdkArchitecture: x86
+        sqAnalysisBreakBuildIfQualityGateFailed: false
+    - task: CopyFiles@2
+      name: CopyFiles1
+      displayName: Copy Files to Artifact Staging Directory
+      inputs:
+        SourceFolder: LinuxBrokerPackage/build/distributions
+        TargetFolder: $(build.artifactstagingdirectory)
+    - task: PublishPipelineArtifact@1
+      name: PublishPipelineArtifacts1
+      displayName: 'Publish Artifact: LinuxBrokerPackage Linux Test App Deb'
+      inputs:
+        ArtifactName: LinuxBrokerPackage Deb Package
+        TargetPath: $(build.artifactstagingdirectory)
 # Msal - Build and publish      
 - stage: 'publishMsal'
   displayName: Msal - Build and publish

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -160,13 +160,14 @@ stages:
       repository: broker
       project: LinuxBroker
       publishCmd: publishAarPublicationToVsts-maven-adal-androidRepository
-      testCmd: linuxBrokerUnitTestCoverageReport -Psystemd_mode_enabled=false --build-cache --info
+      testCmd: linuxBrokerUnitTestCoverageReport
       dependencyParams: $(broker4jVersionParam) $(common4jVersionParam) $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
       publishParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
+      linuxParams: -Psystemd_mode_enabled=false --build-cache --info
       shouldRunLinuxInlineScript: True
   - job: PublishLinuxBrokerPackage
     dependsOn: publishLinuxBrokerLibraries

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -168,7 +168,6 @@ stages:
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
       testParams: $(common4jVersionParam) $(broker4jVersionParam) -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
-      shouldRunLinuxInlineScript: True
   - job: PublishLinuxBrokerPackage
     dependsOn: publishLinuxBrokerLibraries
     displayName: Publish Linux Broker Package

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -167,7 +167,6 @@ stages:
       testCmd: linuxBrokerUnitTestCoverageReport
       dependencyParams: $(broker4jVersionParam) $(common4jVersionParam) $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
-      testParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
       publishParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -160,7 +160,7 @@ stages:
       repository: broker
       project: LinuxBroker
       publishCmd: publishAarPublicationToVsts-maven-adal-androidRepository
-      testCmd: linuxBrokerUnitTestCoverageReport
+      testCmd: linuxBrokerUnitTestCoverageReport -Psystemd_mode_enabled=false --build-cache --info
       dependencyParams: $(broker4jVersionParam) $(common4jVersionParam) $(javaProjectDependencyParam)
       assembleParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)
       publishParams: $(projVersionParam) $(broker4jVersionParam) $(common4jVersionParam)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -167,7 +167,7 @@ stages:
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
-      testParams: $(broker4jVersionParam) $(common4jVersionParam) -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
+      testParams: $(common4jVersionParam) $(broker4jVersionParam) -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
       shouldRunLinuxInlineScript: True
   - job: PublishLinuxBrokerPackage
     dependsOn: publishLinuxBrokerLibraries


### PR DESCRIPTION
WHAT?
Fix the Linux broker testing in the Auth Client Android Daily Release Pipeline : https://identitydivision.visualstudio.com/Engineering/_build?definitionId=1515&_a=summary

We have also added the testParams, specifically for test jobs

A successful run: 
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1101900&view=results

https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1102421&view=logs&j=03c4f6f1-88e4-5ead-1f97-f50c8da9a6d0&t=dcaefdc0-41bf-573b-6391-81b60e4bdc1c

ADO Item: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2574910