### PR TITLE
Implement fail fast into ui automation to monitor infrastructure crashes

### DIFF
--- a/azure-pipelines/ui-automation/templates/flank/flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/flank.yml
@@ -20,3 +20,11 @@ flank:
   # which don't support ansi codes, to avoid corrupted output use single or verbose.
   # The output style `compact` is used to produce less detailed output, it prints just Args, test and matrix count, weblinks, cost, and result reports.
   output-style: verbose
+
+  ## Fail Fast
+  # If true, only a single attempt at most will be made to run each execution/shard in the matrix.
+  # Flaky test attempts are not affected. Normally, 2 or more attempts are made if a potential
+  # infrastructure issue is detected. This feature is for latency sensitive workloads. The
+  # incidence of execution failures may be significantly greater for fail-fast matrices and support
+  # is more limited because of that expectation.
+  fail-fast: false

--- a/azure-pipelines/ui-automation/templates/flank/flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/flank.yml
@@ -27,4 +27,4 @@ flank:
   # infrastructure issue is detected. This feature is for latency sensitive workloads. The
   # incidence of execution failures may be significantly greater for fail-fast matrices and support
   # is more limited because of that expectation.
-  fail-fast: false
+  fail-fast: true

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -46,7 +46,13 @@ jobs:
           secureFile: AndroidFirebaseServiceAccountKey.json
           retryCount: 5
       - download: current
-      - script: gcloud version
+      - script: |
+          curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+          echo "deb https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+          sudo apt-get update
+          sudo apt-get purge man-db
+          sudo apt-get --allow-downgrades install google-cloud-sdk=417.0.1-0
+          gcloud version
         displayName: 'Check gcloud version'
       - task: Bash@3
         env:
@@ -56,6 +62,7 @@ jobs:
         inputs:
           targetType: inline
           script: |
+            gcloud version
             gcloud auth activate-service-account --key-file "$(gcServiceAccountKey.secureFilePath)"
             gcloud config set project "$(gCloudProjectId)"
             gcloud firebase test android models list

--- a/azure-pipelines/ui-automation/templates/run-on-firebase.yml
+++ b/azure-pipelines/ui-automation/templates/run-on-firebase.yml
@@ -73,6 +73,7 @@ jobs:
               --results-dir "${{ parameters.resultsDir }}" \
               --directories-to-pull /sdcard,/data/local/tmp \
               --use-orchestrator \
+              --fail-fast \
               --environment-variables "clearPackageData=true" \
               --results-history-name "${{ parameters.resultsHistoryName }}" \
               --test-targets "${{ parameters.testTargetPackages }}, ${{ parameters.extraTarget }}"


### PR DESCRIPTION
Using this change to monitor ui automation infrastructure issues on firebase over the next few days. Also, downgrade gcloud version as many recent gcloud versions have caused some problems.