### PR TITLE
Fail Fast doesn't work base gcloud firebase command, only flank

### DIFF
--- a/azure-pipelines/ui-automation/templates/run-on-firebase.yml
+++ b/azure-pipelines/ui-automation/templates/run-on-firebase.yml
@@ -73,7 +73,6 @@ jobs:
               --results-dir "${{ parameters.resultsDir }}" \
               --directories-to-pull /sdcard,/data/local/tmp \
               --use-orchestrator \
-              --fail-fast \
               --environment-variables "clearPackageData=true" \
               --results-history-name "${{ parameters.resultsHistoryName }}" \
               --test-targets "${{ parameters.testTargetPackages }}, ${{ parameters.extraTarget }}"


### PR DESCRIPTION
Can't use Fail-fast without flank, at least not that i could find. Might consider moving all ui automation execution to flank and use 1 shard for tests that don't actually need sharding.