### PR TITLE
Fail-fast moved to command line

### DIFF
--- a/azure-pipelines/ui-automation/templates/flank/flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/flank.yml
@@ -20,11 +20,3 @@ flank:
   # which don't support ansi codes, to avoid corrupted output use single or verbose.
   # The output style `compact` is used to produce less detailed output, it prints just Args, test and matrix count, weblinks, cost, and result reports.
   output-style: verbose
-
-  ## Fail Fast
-  # If true, only a single attempt at most will be made to run each execution/shard in the matrix.
-  # Flaky test attempts are not affected. Normally, 2 or more attempts are made if a potential
-  # infrastructure issue is detected. This feature is for latency sensitive workloads. The
-  # incidence of execution failures may be significantly greater for fail-fast matrices and support
-  # is more limited because of that expectation.
-  fail-fast: true

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -80,6 +80,7 @@ jobs:
               --results-dir "${{ parameters.resultsDir }}" \
               --directories-to-pull /sdcard,/data/local/tmp \
               --use-orchestrator \
+              --fail-fast \
               --environment-variables "clearPackageData=true" \
               --results-history-name "${{ parameters.resultsHistoryName }}" \
               --test-targets "${{ parameters.testTargetPackages }}, ${{ parameters.extraTarget }}" \


### PR DESCRIPTION
For some reason, fail-fast wasn't being picked up from flank.yml (even though it's included in the documentation), so moving it to command line directly.

I know that flank.yml is being read as other fields are being set from it, so not sure why this happened. Tested this and made sure it actually sets the field.