### PR TITLE
E2E test pipeline download and install old version of LTW and CP

### DIFF
--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -49,6 +49,7 @@ variables:
   OSServiceConnection: LTW-Integration
   LTWFeedName: Auth-Broker-Integrated-LTW-Build
   LTWApk: LTW-signed.apk
+  oldLTWApk: OldLTW-signed.apk
   
 parameters:
 - name: firebaseDeviceIdHigh
@@ -91,6 +92,10 @@ parameters:
   displayName: Link to Windows Version
   type: string
   default: '*'
+- name: oldLTWVersion
+  displayName: Old Link to Windows Version
+  type: string
+  default: '1.23051.78'
 - name: msalTestTarget
   displayName: Test Targets for MSAL
   type: string
@@ -162,6 +167,7 @@ stages:
         brokerHostPipelineId: '$(brokerHostPipelineId)'
         oldBrokerHostVersion: ${{ parameters.oldBrokerHostVersion }}
         LTWVersion: ${{ parameters.LTWVersion }}
+        oldLTWVersion: ${{ parameters.oldLTWVersion }}
 # MSAL with Broker Test Plan stage (API 30+)
 - stage: 'msal_with_broker_high_api'
   dependsOn:
@@ -180,6 +186,7 @@ stages:
         otherFiles: "/sdcard/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
                       /sdcard/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
+                      /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/$(OldLTWApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
@@ -207,6 +214,7 @@ stages:
         otherFiles: "/sdcard/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
                       /sdcard/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
+                      /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/$(OldLTWApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=/home/vsts/work/1/brokerapks/$(brokerhost_apk),\
@@ -235,6 +243,7 @@ stages:
         otherFiles: "/sdcard/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
                       /sdcard/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
+                      /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/$(OldLTWApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
@@ -264,6 +273,7 @@ stages:
         otherFiles: "/sdcard/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
                       /sdcard/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
+                      /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/$(OldLTWApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -38,6 +38,7 @@ variables:
   brokerApp: brokerautomationapp-dist-AutoBroker-debug.apk
   brokerTestApp: brokerautomationapp-dist-AutoBroker-debug-androidTest.apk
   companyPortalApk: com.microsoft.windowsintune.companyportal-signed.apk
+  oldCompanyPortalApk: com.microsoft.windowsintune.companyportal-signed.apk
   authenticatorApk: app-production-universal-release-signed.apk
   oldAuthenticatorApk: Authenticator-4.1.0-RC.apk
   outlookApk: Outlook.apk
@@ -84,6 +85,10 @@ parameters:
   displayName: Company Portal Version
   type: string
   default: '*'
+- name: oldCompanyPortalVersion
+  displayName: Old Company Portal Version
+  type: string
+  default: '5.0.5729'
 - name: oldBrokerHostVersion
   displayName: Old Broker host Version
   type: string
@@ -164,6 +169,7 @@ stages:
         authenticatorVersion: ${{ parameters.authenticatorVersion }}
         oldAuthenticatorVersion: ${{ parameters.oldAuthenticatorVersion }}
         companyPortalVersion: ${{ parameters.companyPortalVersion }}
+        oldCompanyPortalVersion: ${{ parameters.oldCompanyPortalVersion }}
         brokerHostPipelineId: '$(brokerHostPipelineId)'
         oldBrokerHostVersion: ${{ parameters.oldBrokerHostVersion }}
         LTWVersion: ${{ parameters.LTWVersion }}
@@ -184,6 +190,7 @@ stages:
         resultsHistoryName: "$(resultsHistoryName)"
         resultsDir: "msalautomationapp-testpass-broker-highapi-$(Build.BuildId)-AndroidBrokerCI"
         otherFiles: "/sdcard/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
+                      /sdcard/OldCompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(oldCompanyPortalApk),\
                       /sdcard/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
                       /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldLTWApk),\
@@ -212,6 +219,7 @@ stages:
         resultsHistoryName: "$(resultsHistoryName)"
         resultsDir: "msalautomationapp-testpass-brokerhost-highapi-$(Build.BuildId)-AndroidBrokerCI"
         otherFiles: "/sdcard/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
+                      /sdcard/OldCompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(oldCompanyPortalApk),\
                       /sdcard/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
                       /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldltwApk),\
@@ -241,6 +249,7 @@ stages:
         resultsHistoryName: "$(resultsHistoryName)"
         resultsDir: "msalautomationapp-testpass-broker-lowapi-$(Build.BuildId)-AndroidBrokerCI"
         otherFiles: "/sdcard/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
+                      /sdcard/OldCompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(oldCompanyPortalApk),\
                       /sdcard/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
                       /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldltwApk),\
@@ -271,6 +280,7 @@ stages:
         resultsHistoryName: "$(resultsHistoryName)"
         resultsDir: "brokerautomationapp-testpass-adal&basic-highapi-$(Build.BuildId)-AndroidBrokerCI"
         otherFiles: "/sdcard/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
+                      /sdcard/OldCompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(oldCompanyPortalApk),\
                       /sdcard/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
                       /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldltwApk),\

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -186,7 +186,7 @@ stages:
         otherFiles: "/sdcard/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
                       /sdcard/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
-                      /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/$(OldLTWApk),\
+                      /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldLTWApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
@@ -214,7 +214,7 @@ stages:
         otherFiles: "/sdcard/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
                       /sdcard/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
-                      /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/$(OldLTWApk),\
+                      /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldltwApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=/home/vsts/work/1/brokerapks/$(brokerhost_apk),\
@@ -243,7 +243,7 @@ stages:
         otherFiles: "/sdcard/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
                       /sdcard/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
-                      /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/$(OldLTWApk),\
+                      /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldltwApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
@@ -273,7 +273,7 @@ stages:
         otherFiles: "/sdcard/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
                       /sdcard/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
-                      /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/$(OldLTWApk),\
+                      /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldltwApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -79,7 +79,7 @@ jobs:
         vstsFeedPackage: 'com.azure.authenticator'
         vstsPackageVersion: '${{ parameters.oldAuthenticatorVersion }}'
     - task: UniversalPackages@0
-      displayName: 'Download com.microsoft.windowsintune.companyportal-signed'
+      displayName: 'Download Latest CompanyPortal Apk'
       inputs:
         command: 'download'
         downloadDirectory: '$(Build.ArtifactStagingDirectory)/brokers'
@@ -89,7 +89,7 @@ jobs:
         packageDownloadExternal: 'com.microsoft.windowsintune.companyportal-signed'
         versionDownloadExternal: '${{ parameters.companyPortalVersion }}'
     - task: UniversalPackages@0
-      displayName: 'Download Old com.microsoft.windowsintune.companyportal-signed'
+      displayName: 'Download Old CompanyPortal Apk'
       inputs:
         command: 'download'
         downloadDirectory: '$(Build.ArtifactStagingDirectory)/brokers/oldAPKs'
@@ -99,7 +99,7 @@ jobs:
         packageDownloadExternal: 'com.microsoft.windowsintune.companyportal-signed'
         versionDownloadExternal: '${{ parameters.oldCompanyPortalVersion }}'
     - task: UniversalPackages@0
-      displayName: 'Download com.microsoft.appmanager'
+      displayName: 'Download Latest LTW Apk'
       inputs:
         command: 'download'
         downloadDirectory: '$(Build.ArtifactStagingDirectory)/brokers'
@@ -112,7 +112,7 @@ jobs:
       displayName: 'Rename LTW build to LTW-signed.apk'
       workingDirectory: '$(Build.ArtifactStagingDirectory)/brokers'
     - task: UniversalPackages@0
-      displayName: 'Download old com.microsoft.appmanager'
+      displayName: 'Download Old LTW Apk'
       inputs:
         command: 'download'
         downloadDirectory: '$(Build.ArtifactStagingDirectory)/brokers/oldAPKs'

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -33,6 +33,9 @@ parameters:
     displayName: Link to Windows Version
     type: string
     default: '*'
+  - name: oldLTWVersion
+    displayName: Old Link to Windows Version
+    type: string
 jobs:
 - job: 'download_brokers'
   displayName: Download Brokers
@@ -94,6 +97,19 @@ jobs:
         versionDownloadExternal: '${{ parameters.LTWVersion }}'
     - script: mv ./YPC-*.apk ./LTW-signed.apk
       displayName: 'Rename LTW build to LTW-signed.apk'
+      workingDirectory: '$(Build.ArtifactStagingDirectory)/brokers'
+    - task: UniversalPackages@0
+      displayName: 'Download old com.microsoft.appmanager'
+      inputs:
+        command: 'download'
+        downloadDirectory: '$(Build.ArtifactStagingDirectory)/brokers'
+        feedsToUse: 'external'
+        externalFeedCredentials: '${{ parameters.OSServiceConnection }}'
+        feedDownloadExternal: '${{ parameters.LTWFeedName }}'
+        packageDownloadExternal: 'com.microsoft.appmanager'
+        versionDownloadExternal: '${{ parameters.OldLTWVersion }}'
+    - script: mv ./YPC-*.apk ./OldLTW-signed.apk
+      displayName: 'Rename Old LTW build to OldLTW-signed.apk'
       workingDirectory: '$(Build.ArtifactStagingDirectory)/brokers'
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Broker Host'

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -16,6 +16,9 @@ parameters:
   - name: companyPortalVersion
     displayName: Company Portal Version
     type: string
+  - name: oldCompanyPortalVersion
+    displayName: Old Company Portal Version
+    type: string
   - name: brokerHostPipelineId
     type: string
   - name: oldBrokerHostVersion
@@ -85,6 +88,16 @@ jobs:
         feedDownloadExternal: '${{ parameters.msazureFeedName }}'
         packageDownloadExternal: 'com.microsoft.windowsintune.companyportal-signed'
         versionDownloadExternal: '${{ parameters.companyPortalVersion }}'
+    - task: UniversalPackages@0
+      displayName: 'Download Old com.microsoft.windowsintune.companyportal-signed'
+      inputs:
+        command: 'download'
+        downloadDirectory: '$(Build.ArtifactStagingDirectory)/brokers/oldAPKs'
+        feedsToUse: 'external'
+        externalFeedCredentials: '${{ parameters.msazureServiceConnection }}'
+        feedDownloadExternal: '${{ parameters.msazureFeedName }}'
+        packageDownloadExternal: 'com.microsoft.windowsintune.companyportal-signed'
+        versionDownloadExternal: '${{ parameters.oldCompanyPortalVersion }}'
     - task: UniversalPackages@0
       displayName: 'Download com.microsoft.appmanager'
       inputs:

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -102,7 +102,7 @@ jobs:
       displayName: 'Download old com.microsoft.appmanager'
       inputs:
         command: 'download'
-        downloadDirectory: '$(Build.ArtifactStagingDirectory)/brokers'
+        downloadDirectory: '$(Build.ArtifactStagingDirectory)/brokers/oldAPKs'
         feedsToUse: 'external'
         externalFeedCredentials: '${{ parameters.OSServiceConnection }}'
         feedDownloadExternal: '${{ parameters.LTWFeedName }}'
@@ -110,7 +110,7 @@ jobs:
         versionDownloadExternal: '${{ parameters.OldLTWVersion }}'
     - script: mv ./YPC-*.apk ./OldLTW-signed.apk
       displayName: 'Rename Old LTW build to OldLTW-signed.apk'
-      workingDirectory: '$(Build.ArtifactStagingDirectory)/brokers'
+      workingDirectory: '$(Build.ArtifactStagingDirectory)/brokers/oldAPKs'
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Broker Host'
       inputs:

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -16,9 +16,11 @@ parameters:
   - name: companyPortalVersion
     displayName: Company Portal Version
     type: string
+    default: '*'
   - name: oldCompanyPortalVersion
     displayName: Old Company Portal Version
     type: string
+    default: '5.0.5729'
   - name: brokerHostPipelineId
     type: string
   - name: oldBrokerHostVersion
@@ -39,6 +41,7 @@ parameters:
   - name: oldLTWVersion
     displayName: Old Link to Windows Version
     type: string
+    default: '1.23051.78'
 jobs:
 - job: 'download_brokers'
   displayName: Download Brokers


### PR DESCRIPTION
In order to support update scenarios, we need to download old version of LTW and CompanyPortal.

- Changed "broker-test.yml" to pass old version name of LTW and CP to "download-brokers-and-azure-sample.yml".
- Changed "broker-test.yml" to push old version apks of LTW and CP to firebase devices.
- Changed "download-brokers-and-azure-sample.yml" to consume old version name of LTW and CP to download them to brokerapks/oldAPKs directory.