### PR TITLE
Add preinstallLtw parameter

### DIFF
--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -99,7 +99,7 @@ parameters:
   displayName: Test Targets for Broker
   type: string
   default: package com.microsoft.identity.client.broker.automationapp.testpass, notAnnotation org.junit.Ignore, notAnnotation com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline
-- name: preinstallLtw
+- name: preInstallLtw
   displayName: Preinstall Link to Windows
   type: boolean
   default: false
@@ -118,7 +118,7 @@ stages:
         brokerUpdateSource: LocalApk
         msalVersion: "0.0.+"
         packageVariant: RC
-        preinstallLtw: ${{ parameters.preinstallLtw }}
+        preInstallLtw: ${{ parameters.preInstallLtw }}
 # msalautomationapplocalbrokerhost
 - stage: 'msalautomationapplocalbrokerhost'
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
@@ -132,7 +132,7 @@ stages:
         brokerUpdateSource: LocalApk
         msalVersion: "0.0.+"
         packageVariant: RC
-        preinstallLtw: ${{ parameters.preinstallLtw }}
+        preInstallLtw: ${{ parameters.preInstallLtw }}
 # brokerautomationapp
 - stage: 'brokerautomationapp'
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
@@ -145,7 +145,7 @@ stages:
         brokerSource: LocalApk
         adalVersion: "0.0.+"
         commonVersion: "0.0.+"
-        preinstallLtw: ${{ parameters.preinstallLtw }}
+        preInstallLtw: ${{ parameters.preInstallLtw }}
 # Download First Party Apps
 - stage: 'firstpartyapps'
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -99,6 +99,10 @@ parameters:
   displayName: Test Targets for Broker
   type: string
   default: package com.microsoft.identity.client.broker.automationapp.testpass, notAnnotation org.junit.Ignore, notAnnotation com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline
+- name: preinstallLtw
+  displayName: Preinstall Link to Windows
+  type: boolean
+  default: false
 
 stages:
 # msalautomationapp
@@ -114,6 +118,7 @@ stages:
         brokerUpdateSource: LocalApk
         msalVersion: ""
         packageVariant: RC
+        preinstallLtw: ${{ parameters.preinstallLtw }}
 # msalautomationapplocalbrokerhost
 - stage: 'msalautomationapplocalbrokerhost'
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
@@ -127,6 +132,7 @@ stages:
         brokerUpdateSource: LocalApk
         msalVersion: ""
         packageVariant: RC
+        preinstallLtw: ${{ parameters.preinstallLtw }}
 # brokerautomationapp
 - stage: 'brokerautomationapp'
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
@@ -137,6 +143,7 @@ stages:
         brokerApp: AutoBroker
         brokerFlavor: Dist
         brokerSource: LocalApk
+        preinstallLtw: ${{ parameters.preinstallLtw }}
 # Download First Party Apps
 - stage: 'firstpartyapps'
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel

--- a/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
@@ -53,7 +53,7 @@ jobs:
         targetType: inline
         script: |
           $assembleTask = clean brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}
-          if (${{ parameters.preinstallLtw }}) {
+          if (parameters.preinstallLtw) {
               $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
@@ -68,7 +68,7 @@ jobs:
         targetType: inline
         script: |
           $assembleTask = brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)
-          if (${{ parameters.preinstallLtw }}) {
+          if (parameters.preinstallLtw) {
               $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTask"

--- a/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
@@ -54,7 +54,7 @@ jobs:
         script: |
           $assembleTask = clean brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}
           if ((${{ parameters.preinstallLtw }})) {
-              $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
+              $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
     - task: Gradle@2
@@ -69,7 +69,7 @@ jobs:
         script: |
           $assembleTask = brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)
           if ((${{ parameters.preinstallLtw }})) {
-              $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
+              $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTask"
     - task: Gradle@2

--- a/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
@@ -20,6 +20,9 @@ parameters:
     values:
       - LocalApk
       - PlayStore
+  - name: preinstallLtw
+    type: boolean
+    default: false
 
 jobs:
 - job: brokerautomationapp
@@ -44,15 +47,35 @@ jobs:
         KeyVaultName: 'ADALTestInfo'
         SecretsFilter: 'AndroidAutomationRunnerAppSecret'
         RunAsPreJob: false
+    - task: PowerShell@2
+      displayName: Generate Assemble Clean Task
+      inputs:
+        targetType: inline
+        script: |
+          $assembleTask = clean brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}
+          if ((${{ parameters.preinstallLtw }})) {
+              $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
+          }
+          Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
     - task: Gradle@2
       displayName: 'Assemble Broker Automation App'
       inputs:
-        tasks: clean brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}
+        tasks: $(AssembleTask)
         publishJUnitResults: false
+    - task: PowerShell@2
+      displayName: Generate Assemble Test Task
+      inputs:
+        targetType: inline
+        script: |
+          $assembleTask = brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)
+          if ((${{ parameters.preinstallLtw }})) {
+              $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
+          }
+          Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTask"
     - task: Gradle@2
       displayName: 'Assemble Broker Automation App Instrumented Tests'
       inputs:
-        tasks: brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)
+        tasks: $(AssembleTestTask)
         publishJUnitResults: false
     - task: CopyFiles@2
       displayName: 'Copy apks for later use in the pipeline'

--- a/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
@@ -52,7 +52,7 @@ jobs:
       inputs:
         targetType: inline
         script: |
-          $assembleTask = clean brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}
+          $assembleTask = "clean brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}"
           if ("${{ parameters.preinstallLtw }}" -eq "True") {
               $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
@@ -67,7 +67,7 @@ jobs:
       inputs:
         targetType: inline
         script: |
-          $assembleTask = brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)
+          $assembleTask = "brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)"
           if ("${{ parameters.preinstallLtw }}" -eq "True") {
               $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }

--- a/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
@@ -53,7 +53,7 @@ jobs:
         targetType: inline
         script: |
           $assembleTask = clean brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}
-          if (${{ parameters.preinstallLtw }}) {
+          if (${{ parameters.preinstallLtw }} -eq $true) {
               $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
@@ -68,7 +68,7 @@ jobs:
         targetType: inline
         script: |
           $assembleTask = brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)
-          if (${{ parameters.preinstallLtw }}) {
+          if (${{ parameters.preinstallLtw }} -eq $true) {
               $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTask"

--- a/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
@@ -53,7 +53,7 @@ jobs:
         targetType: inline
         script: |
           $assembleTask = clean brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}
-          if (${{ parameters.preinstallLtw }} -eq $true) {
+          if ${{ parameters.preinstallLtw }} {
               $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
@@ -68,7 +68,7 @@ jobs:
         targetType: inline
         script: |
           $assembleTask = brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)
-          if (${{ parameters.preinstallLtw }} -eq $true) {
+          if ${{ parameters.preinstallLtw }} {
               $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTask"

--- a/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
@@ -53,7 +53,7 @@ jobs:
         targetType: inline
         script: |
           $assembleTask = clean brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}
-          if ${{ parameters.preinstallLtw }} {
+          if (${{ parameters.preinstallLtw }}) {
               $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
@@ -68,7 +68,7 @@ jobs:
         targetType: inline
         script: |
           $assembleTask = brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)
-          if ${{ parameters.preinstallLtw }} {
+          if (${{ parameters.preinstallLtw }}) {
               $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTask"

--- a/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
@@ -53,7 +53,7 @@ jobs:
         targetType: inline
         script: |
           $assembleTask = clean brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}
-          if (parameters.preinstallLtw) {
+          if ("${{ parameters.preinstallLtw }}" -eq "True") {
               $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
@@ -68,7 +68,7 @@ jobs:
         targetType: inline
         script: |
           $assembleTask = brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)
-          if (parameters.preinstallLtw) {
+          if ("${{ parameters.preinstallLtw }}" -eq "True") {
               $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTask"

--- a/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
@@ -20,7 +20,7 @@ parameters:
     values:
       - LocalApk
       - PlayStore
-  - name: preinstallLtw
+  - name: preInstallLtw
     type: boolean
     default: false
   - name: adalVersion
@@ -67,8 +67,8 @@ jobs:
           if (("${{ parameters.commonVersion }}" -ne "")) {
               $assembleTask = $assembleTask + " -PdistCommonVersion=" + "${{ parameters.commonVersion }}"
           }
-          if ("${{ parameters.preinstallLtw }}" -eq "True") {
-              $assembleTask = $assembleTask + " -PpreinstallLtw=true"
+          if ("${{ parameters.preInstallLtw }}" -eq "True") {
+              $assembleTask = $assembleTask + " -PpreInstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
     - task: Gradle@2
@@ -88,8 +88,8 @@ jobs:
           if (("${{ parameters.commonVersion }}" -ne "")) {
               $assembleTestTask = $assembleTestTask + " -PdistCommonVersion=" + "${{ parameters.commonVersion }}"
           }
-          if ("${{ parameters.preinstallLtw }}" -eq "True") {
-              $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
+          if ("${{ parameters.preInstallLtw }}" -eq "True") {
+              $assembleTestTask = $assembleTestTask + " -PpreInstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTestTask"
     - task: Gradle@2

--- a/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
@@ -53,7 +53,7 @@ jobs:
         targetType: inline
         script: |
           $assembleTask = clean brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}
-          if ((${{ parameters.preinstallLtw }})) {
+          if (${{ parameters.preinstallLtw }}) {
               $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
@@ -68,7 +68,7 @@ jobs:
         targetType: inline
         script: |
           $assembleTask = brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)
-          if ((${{ parameters.preinstallLtw }})) {
+          if (${{ parameters.preinstallLtw }}) {
               $assembleTask = $assembleTask + " -PpreinstallLtw=true"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTask"

--- a/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
@@ -71,7 +71,7 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTask = $assembleTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
-            if (${{ parameters.preinstallLtw }}) {
+            if (parameters.preinstallLtw) {
                 $assembleTask = $assembleTask + " -PpreinstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
@@ -89,7 +89,7 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTestTask = $assembleTestTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
-            if (${{ parameters.preinstallLtw }}) {
+            if (parameters.preinstallLtw) {
                 $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTestTask"

--- a/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
@@ -71,7 +71,7 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTask = $assembleTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
-            if (${{ parameters.preinstallLtw }}) {
+            if (${{ parameters.preinstallLtw }} -eq $true) {
                 $assembleTask = $assembleTask + " -PpreinstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
@@ -89,7 +89,7 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTestTask = $assembleTestTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
-            if (${{ parameters.preinstallLtw }}) {
+            if (${{ parameters.preinstallLtw }} -eq $true) {
                 $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTestTask"

--- a/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
@@ -39,7 +39,7 @@ parameters:
   - name: artifactName
     type: string
     default: "msalautomationapks"
-  - name: preinstallLtw
+  - name: preInstallLtw
     type: boolean
     default: false
 
@@ -72,8 +72,8 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTask = $assembleTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
-            if ("${{ parameters.preinstallLtw }}" -eq "True") {
-                $assembleTask = $assembleTask + " -PpreinstallLtw=true"
+            if ("${{ parameters.preInstallLtw }}" -eq "True") {
+                $assembleTask = $assembleTask + " -PpreInstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
       - task: Gradle@2
@@ -90,8 +90,8 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTestTask = $assembleTestTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
-            if ("${{ parameters.preinstallLtw }}" -eq "True") {
-                $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
+            if ("${{ parameters.preInstallLtw }}" -eq "True") {
+                $assembleTestTask = $assembleTestTask + " -PpreInstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTestTask"
       - task: Gradle@2

--- a/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
@@ -71,7 +71,7 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTask = $assembleTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
-            if (parameters.preinstallLtw) {
+            if ("${{ parameters.preinstallLtw }}" -eq "True") {
                 $assembleTask = $assembleTask + " -PpreinstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
@@ -89,7 +89,7 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTestTask = $assembleTestTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
-            if (parameters.preinstallLtw) {
+            if ("${{ parameters.preinstallLtw }}" -eq "True") {
                 $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTestTask"

--- a/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
@@ -71,7 +71,7 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTask = $assembleTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
-            if ${{ parameters.preinstallLtw }} {
+            if (${{ parameters.preinstallLtw }}) {
                 $assembleTask = $assembleTask + " -PpreinstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
@@ -89,7 +89,7 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTestTask = $assembleTestTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
-            if ${{ parameters.preinstallLtw }} {
+            if (${{ parameters.preinstallLtw }}) {
                 $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTestTask"

--- a/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
@@ -72,7 +72,7 @@ jobs:
                 $assembleTask = $assembleTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
             if ((${{ parameters.preinstallLtw }})) {
-                $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
+                $assembleTask = $assembleTask + " -PpreinstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
       - task: Gradle@2

--- a/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
@@ -71,7 +71,7 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTask = $assembleTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
-            if (${{ parameters.preinstallLtw }} -eq $true) {
+            if ${{ parameters.preinstallLtw }} {
                 $assembleTask = $assembleTask + " -PpreinstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
@@ -89,7 +89,7 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTestTask = $assembleTestTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
-            if (${{ parameters.preinstallLtw }} -eq $true) {
+            if ${{ parameters.preinstallLtw }} {
                 $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTestTask"

--- a/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
@@ -38,6 +38,9 @@ parameters:
   - name: artifactName
     type: string
     default: "msalautomationapks"
+  - name: preinstallLtw
+    type: boolean
+    default: false
 
 jobs:
   - job: msalautomationapp${{ parameters.packageVariant }}${{ parameters.msalFlavor }}
@@ -68,6 +71,9 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTask = $assembleTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
+            if ((${{ parameters.preinstallLtw }})) {
+                $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
+            }
             Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
       - task: Gradle@2
         displayName: 'Assemble MSAL Automation App'
@@ -82,6 +88,9 @@ jobs:
             $assembleTestTask = "msalautomationapp:assemble${{ parameters.msalFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)"
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTestTask = $assembleTestTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
+            }
+            if ((${{ parameters.preinstallLtw }})) {
+                $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTestTask"
       - task: Gradle@2

--- a/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
@@ -71,7 +71,7 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTask = $assembleTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
-            if ((${{ parameters.preinstallLtw }})) {
+            if (${{ parameters.preinstallLtw }}) {
                 $assembleTask = $assembleTask + " -PpreinstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
@@ -89,7 +89,7 @@ jobs:
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTestTask = $assembleTestTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
-            if ((${{ parameters.preinstallLtw }})) {
+            if (${{ parameters.preinstallLtw }}) {
                 $assembleTestTask = $assembleTestTask + " -PpreinstallLtw=true"
             }
             Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTestTask"


### PR DESCRIPTION
In build-msal-automation-app.yml template (android-complete\msal\azure-pipelines\ui-automation\templates), we should add -PpreInstallLtw=$(parameters. preInstallLtw) in “Assemble MSAL Automation App” and “Assemble MSAL Automation App Instrumented Tests”. Also add the variable in the parameters.  Note : This is not a separate pipeline, it is a template used in the [UI automation pipeline](https://identitydivision.visualstudio.com/Engineering/_build?definitionId=1490&_a=summary) 

Same as above step in build-broker-automation-app.yml template file as well. 

Next, in broker-test.yml file ([UI automation pipeline](https://identitydivision.visualstudio.com/Engineering/_build?definitionId=1490&_a=summary)), wherever we use the above two templates, pass the parameter preInstallLtw: ${{ parameters. preInstallLtw }} 

This means that we can set this flag when we trigger the pipeline. Verify if the pipeline succeeds when the flag is true and false. All the existing testcases should succeed in both cases. If some testcase fails, please feel free to ask help from Broker team on why this could affect an existing testcase.