### PR TITLE
Running instrumented tests as part of daily pipeline

### DIFF
--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -125,3 +125,8 @@ jobs:
       inputs:
         summaryFileLocation: '$(Build.SourcesDirectory)/${{ parameters.project }}/build/reports/jacoco/${{ parameters.testCmd }}/${{ parameters.testCmd }}.xml'
         reportDirectory: '$(Build.SourcesDirectory)/${{ parameters.project }}/build/reports/jacoco/${{ parameters.testCmd }}/html'
+- ${{ if and(ne(parameters.project, 'LinuxBroker'), ne(parameters.project, 'common4j'), ne(parameters.project, 'broker4j')) }}:
+  - template: ../templates/run-instrumented-tests.yml
+    parameters:
+      gitProject: ${{ parameters.repository }}
+      projectName: ${{ parameters.project }}

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -125,8 +125,11 @@ jobs:
       inputs:
         summaryFileLocation: '$(Build.SourcesDirectory)/${{ parameters.project }}/build/reports/jacoco/${{ parameters.testCmd }}/${{ parameters.testCmd }}.xml'
         reportDirectory: '$(Build.SourcesDirectory)/${{ parameters.project }}/build/reports/jacoco/${{ parameters.testCmd }}/html'
-- ${{ if and(ne(parameters.project, 'LinuxBroker'), ne(parameters.project, 'common4j'), ne(parameters.project, 'broker4j')) }}:
-  - template: ../templates/run-instrumented-tests.yml
-    parameters:
-      gitProject: ${{ parameters.repository }}
-      projectName: ${{ parameters.project }}
+- ${{if or(eq(parameters.project, 'common'), eq(parameters.project, 'msal'), eq(parameters.project, 'adal'), eq(parameters.project, 'AADAuthenticator'))}}:
+    - template: ../templates/run-instrumented-tests.yml
+      parameters:
+        gitProject: ${{ parameters.repository }}
+        projectName: ${{ parameters.project }}
+        accessTokenKey: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
+        gradleOptions: -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret)
+        continueOnError: True

--- a/azure-pipelines/templates/run-instrumented-tests.yml
+++ b/azure-pipelines/templates/run-instrumented-tests.yml
@@ -25,6 +25,9 @@ parameters:
 # Key used to store the access token, AT for the Android DevX Feed.
 - name: accessTokenKey
   default: none
+- name: continueOnError
+  type: boolean
+  default: True
 
 jobs:
 - job:
@@ -75,6 +78,8 @@ jobs:
       echo "Emulator started"
     displayName: 'Starting android emulator'
   - task: Gradle@3
+    displayName: Run Instrumented Test ${{ parameters.projectName }}
+    continueOnError: ${{ parameters.continueOnError }}
     inputs:
       gradleWrapperFile: 'gradlew'
       options: ${{ parameters.gradleOptions }}

--- a/settings.gradle
+++ b/settings.gradle
@@ -67,14 +67,14 @@ project(':uiautomationutilities').projectDir = new File('common/uiautomationutil
 include(":brokerautomationapp")
 project(':brokerautomationapp').projectDir = new File('broker/brokerautomationapp')
 
-include(":oneauth")
-project(':oneauth').projectDir = new File('oneauth/sources/android/gradle')
-
-include(":oneauthtestapp")
-project(':oneauthtestapp').projectDir = new File('oneauth/testapps/android/oneauthtestapp/app')
-
-include(":msalcpptesthost")
-project(':msalcpptesthost').projectDir = new File('msalcpp/test/android/testhost/app')
+//include(":oneauth")
+//project(':oneauth').projectDir = new File('oneauth/sources/android/gradle')
+//
+//include(":oneauthtestapp")
+//project(':oneauthtestapp').projectDir = new File('oneauth/testapps/android/oneauthtestapp/app')
+//
+//include(":msalcpptesthost")
+//project(':msalcpptesthost').projectDir = new File('msalcpp/test/android/testhost/app')
 
 // Pure Java DevX Projects
 include(':common4j')


### PR DESCRIPTION
Adding a job to run instrumented tests as part of daily pipeline run.
We have good set of tests that run as part of instrumented tests, making them part of daily pipeline run, so that we can pay close attention to when something starts failing in these tests.

The new job will run instrumented tests for Common. Broker, Adal and Msal
Here is a sample run: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1108674&view=results