### PR TITLE
Updating pipelines to use appropriate library versions when running UI Automation

### DIFF
--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -557,6 +557,7 @@ stages:
         brokerFlavor: Dist
         brokerSource: LocalApk
         adalVersion: ${{ parameters.adalVersionRC }}
+        commonVersion: ${{ parameters.commonVersionRC }}
 # Download First Party Apps
 - stage: 'firstpartyapps'
   dependsOn:

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -550,6 +550,7 @@ stages:
         brokerApp: AutoBroker
         brokerFlavor: Dist
         brokerSource: LocalApk
+        adalVersion: ${{ parameters.adalVersionRC }}
 # Download First Party Apps
 - stage: 'firstpartyapps'
   dependsOn:

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -112,7 +112,7 @@ stages:
         msalFlavor: Dist
         brokerSource: LocalApk
         brokerUpdateSource: LocalApk
-        msalVersion: ""
+        msalVersion: "0.0.+"
         packageVariant: RC
 # msalautomationapplocalbrokerhost
 - stage: 'msalautomationapplocalbrokerhost'
@@ -125,7 +125,7 @@ stages:
         msalFlavor: Local
         brokerSource: LocalApk
         brokerUpdateSource: LocalApk
-        msalVersion: ""
+        msalVersion: "0.0.+"
         packageVariant: RC
 # brokerautomationapp
 - stage: 'brokerautomationapp'
@@ -137,6 +137,7 @@ stages:
         brokerApp: AutoBroker
         brokerFlavor: Dist
         brokerSource: LocalApk
+        adalVersion: "0.0.+"
 # Download First Party Apps
 - stage: 'firstpartyapps'
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
@@ -162,6 +163,7 @@ stages:
         brokerHostPipelineId: '$(brokerHostPipelineId)'
         oldBrokerHostVersion: ${{ parameters.oldBrokerHostVersion }}
         LTWVersion: ${{ parameters.LTWVersion }}
+
 # MSAL with Broker Test Plan stage (API 30+)
 - stage: 'msal_with_broker_high_api'
   dependsOn:

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -138,6 +138,7 @@ stages:
         brokerFlavor: Dist
         brokerSource: LocalApk
         adalVersion: "0.0.+"
+        commonVersion: "0.0.+"
 # Download First Party Apps
 - stage: 'firstpartyapps'
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel

--- a/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
@@ -49,30 +49,30 @@ jobs:
         SecretsFilter: 'AndroidAutomationRunnerAppSecret'
         RunAsPreJob: false
     - task: PowerShell@2
-        displayName: Generate Assemble Dist Task
-        inputs:
-          targetType: inline
-          script: |
-            $assembleTask = "brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}"
-            if (("${{ parameters.adalVersion }}" -ne "")) {
-                $assembleTask = $assembleTask + " -PdistAdalVersion=" + "${{ parameters.adalVersion }}"
-            }
-            Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
+      displayName: Generate Assemble Dist Task
+      inputs:
+        targetType: inline
+        script: |
+          $assembleTask = "brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}"
+          if (("${{ parameters.adalVersion }}" -ne "")) {
+              $assembleTask = $assembleTask + " -PdistAdalVersion=" + "${{ parameters.adalVersion }}"
+          }
+          Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
     - task: Gradle@2
       displayName: 'Assemble Broker Automation App'
       inputs:
         tasks: brokerautomationapp:clean $(AssembleTask)
         publishJUnitResults: false
     - task: PowerShell@2
-        displayName: Generate Assemble Test Task
-        inputs:
-          targetType: inline
-          script: |
-            $assembleTestTask = "brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)"
-            if (("${{ parameters.adalVersion }}" -ne "")) {
-                $assembleTestTask = $assembleTestTask + " -PdistAdalVersion=" + "${{ parameters.adalVersion }}"
-            }
-            Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTestTask"
+      displayName: Generate Assemble Test Task
+      inputs:
+        targetType: inline
+        script: |
+          $assembleTestTask = "brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)"
+          if (("${{ parameters.adalVersion }}" -ne "")) {
+              $assembleTestTask = $assembleTestTask + " -PdistAdalVersion=" + "${{ parameters.adalVersion }}"
+          }
+          Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTestTask"
     - task: Gradle@2
       displayName: 'Assemble Broker Automation App Instrumented Tests'
       inputs:

--- a/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
@@ -24,6 +24,10 @@ parameters:
     displayName: ADAL Version
     type: string
     default: ""
+  - name: commonVersion
+    displayName: Common Version
+    type: string
+    default: ""
 
 jobs:
 - job: brokerautomationapp
@@ -57,6 +61,9 @@ jobs:
           if (("${{ parameters.adalVersion }}" -ne "")) {
               $assembleTask = $assembleTask + " -PdistAdalVersion=" + "${{ parameters.adalVersion }}"
           }
+          if (("${{ parameters.commonVersion }}" -ne "")) {
+              $assembleTask = $assembleTask + " -PdistCommonVersion=" + "${{ parameters.commonVersion }}"
+          }
           Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
     - task: Gradle@2
       displayName: 'Assemble Broker Automation App'
@@ -71,6 +78,9 @@ jobs:
           $assembleTestTask = "brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)"
           if (("${{ parameters.adalVersion }}" -ne "")) {
               $assembleTestTask = $assembleTestTask + " -PdistAdalVersion=" + "${{ parameters.adalVersion }}"
+          }
+          if (("${{ parameters.commonVersion }}" -ne "")) {
+              $assembleTestTask = $assembleTestTask + " -PdistCommonVersion=" + "${{ parameters.commonVersion }}"
           }
           Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTestTask"
     - task: Gradle@2

--- a/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-automation-app.yml
@@ -20,6 +20,10 @@ parameters:
     values:
       - LocalApk
       - PlayStore
+  - name: adalVersion
+    displayName: ADAL Version
+    type: string
+    default: ""
 
 jobs:
 - job: brokerautomationapp
@@ -44,15 +48,35 @@ jobs:
         KeyVaultName: 'ADALTestInfo'
         SecretsFilter: 'AndroidAutomationRunnerAppSecret'
         RunAsPreJob: false
+    - task: PowerShell@2
+        displayName: Generate Assemble Dist Task
+        inputs:
+          targetType: inline
+          script: |
+            $assembleTask = "brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}"
+            if (("${{ parameters.adalVersion }}" -ne "")) {
+                $assembleTask = $assembleTask + " -PdistAdalVersion=" + "${{ parameters.adalVersion }}"
+            }
+            Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
     - task: Gradle@2
       displayName: 'Assemble Broker Automation App'
       inputs:
-        tasks: clean brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=${{ parameters.brokerSource }}
+        tasks: brokerautomationapp:clean $(AssembleTask)
         publishJUnitResults: false
+    - task: PowerShell@2
+        displayName: Generate Assemble Test Task
+        inputs:
+          targetType: inline
+          script: |
+            $assembleTestTask = "brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)"
+            if (("${{ parameters.adalVersion }}" -ne "")) {
+                $assembleTestTask = $assembleTestTask + " -PdistAdalVersion=" + "${{ parameters.adalVersion }}"
+            }
+            Write-Host "##vso[task.setvariable variable=AssembleTestTask;]$assembleTestTask"
     - task: Gradle@2
       displayName: 'Assemble Broker Automation App Instrumented Tests'
       inputs:
-        tasks: brokerautomationapp:assemble${{ parameters.brokerFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)
+        tasks: $(AssembleTestTask)
         publishJUnitResults: false
     - task: CopyFiles@2
       displayName: 'Copy apks for later use in the pipeline'

--- a/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
@@ -28,6 +28,7 @@ parameters:
   - name: msalVersion
     displayName: MSAL Version
     type: string
+    default: ""
   - name: packageVariant
     displayName: Package Variant
     type: string


### PR DESCRIPTION
Recently we made some changes to brokerautomationapp that changed the dist library version used for adal to use the most recent released version, rather than the daily pipeline version. This PR includes changes to utilize the -Pdist command line parameters in brokerautomationapp and msalautomationapp to pass the correct library versions depending on which pipeline is running automation.

For daily pipeline, we use 0.0.+
for release pipeline, we use the lib versions passed as pipeline parameters.

Keep in mind that these versions only encompass msal and adal version in their respective automation app. broker version is not handled in this way, as it is passed directly when building the broker apps used in our tests

Passing pipelines
https://dev.azure.com/IdentityDivision/Engineering/_build/results?buildId=1109356&view=results
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1109359&view=results