### PR TITLE
Download old Msal & OneAuth Test apps

### DIFF
--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -276,6 +276,7 @@ stages:
   - firstpartyapps
   - oneAuthTestApp
   - msalE2ETestApp
+  - old_test_apps
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
   jobs:
     - template: ./templates/flank/run-on-firebase-with-flank.yml
@@ -311,6 +312,7 @@ stages:
     - firstpartyapps
     - oneAuthTestApp
     - msalE2ETestApp
+    - old_test_apps
   displayName: Running MSAL with Broker Test Plan (BrokerHost Tests) (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
   jobs:
     - template: ./templates/run-on-firebase.yml
@@ -348,6 +350,7 @@ stages:
     - firstpartyapps
     - oneAuthTestApp
     - msalE2ETestApp
+    - old_test_apps
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionLow }})
   jobs:
     - template: ./templates/run-on-firebase.yml

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -200,8 +200,8 @@ stages:
     - template: ./templates/download-old-test-apps.yml
       parameters:
         feedName: '$(testAppsFeedName)'
-        oldMsalTestAppVersion: '$(oldMsalTestAppVersion)'
-        oldOneAuthTestAppVersion: '$(oldOneAuthTestAppVersion)'
+        oldMsalTestAppVersion: ${{ parameters.oldMsalTestAppVersion }}
+        oldOneAuthTestAppVersion: ${{ parameters.oldOneAuthTestAppVersion }}
 # MSAL with Broker Test Plan stage (API 30+)
 - stage: 'msal_with_broker_high_api'
   dependsOn:

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -51,6 +51,7 @@ variables:
   LTWFeedName: Auth-Broker-Integrated-LTW-Build
   LTWApk: LTW-signed.apk
   oldLTWApk: OldLTW-signed.apk
+  testAppsFeedName: BrokerE2ETestApps
   
 parameters:
 - name: firebaseDeviceIdHigh
@@ -101,6 +102,14 @@ parameters:
   displayName: Old Link to Windows Version
   type: string
   default: '1.23051.78'
+- name: oldMsalTestAppVersion
+  displayName: Old MSAL Test App Version
+  type: string
+  default: '4.5.0'
+- name: oldOneAuthTestAppVersion
+  displayName: Old OneAuth Test App Version
+  type: string
+  default: '1.0.0'
 - name: msalTestTarget
   displayName: Test Targets for MSAL
   type: string
@@ -183,7 +192,16 @@ stages:
         oldBrokerHostVersion: ${{ parameters.oldBrokerHostVersion }}
         LTWVersion: ${{ parameters.LTWVersion }}
         oldLTWVersion: ${{ parameters.oldLTWVersion }}
-
+# Download Old Test Apps
+- stage: 'old_test_apps'
+  dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
+  displayName: Download Old Test Apps
+  jobs:
+    - template: ./templates/download-old-test-apps.yml
+      parameters:
+        feedName: '$(testAppsFeedName)'
+        oldMsalTestAppVersion: '$(oldMsalTestAppVersion)'
+        oldOneAuthTestAppVersion: '$(oldOneAuthTestAppVersion)'
 # MSAL with Broker Test Plan stage (API 30+)
 - stage: 'msal_with_broker_high_api'
   dependsOn:

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -51,7 +51,7 @@ variables:
   LTWFeedName: Auth-Broker-Integrated-LTW-Build
   LTWApk: LTW-signed.apk
   oldLTWApk: OldLTW-signed.apk
-  testAppsFeedName: BrokerE2ETestApps
+  testAppsFeedName: Engineering/BrokerE2ETestApps
   
 parameters:
 - name: firebaseDeviceIdHigh

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -223,6 +223,8 @@ stages:
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
                       /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldLTWApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
+                      /sdcard/OldMsalTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(msalE2ETestApp),\
+                      /sdcard/OldOneAuthTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(oneAuthTestApp),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
                       /sdcard/Edge.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk)"
@@ -253,6 +255,8 @@ stages:
                       /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldltwApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/OldBrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhost_apk),\
+                      /sdcard/OldMsalTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(msalE2ETestApp),\
+                      /sdcard/OldOneAuthTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(oneAuthTestApp),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=/home/vsts/work/1/brokerapks/$(brokerhost_apk),\
                       /data/local/tmp/test/DirectPushBrokerHost.apk=/home/vsts/work/1/brokerapks/$(brokerhost_apk),\
@@ -283,6 +287,8 @@ stages:
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
                       /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldltwApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
+                      /sdcard/OldMsalTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(msalE2ETestApp),\
+                      /sdcard/OldOneAuthTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(oneAuthTestApp),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
                       /sdcard/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -112,7 +112,7 @@ parameters:
 - name: oldOneAuthTestAppVersion
   displayName: Old OneAuth Test App Version
   type: string
-  default: '1.0.0'
+  default: '0.20230614.1'
 - name: msalTestTarget
   displayName: Test Targets for MSAL
   type: string

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -54,6 +54,7 @@ variables:
   LTWFeedName: Auth-Broker-Integrated-LTW-Build
   LTWApk: LTW-signed.apk
   oldLTWApk: OldLTW-signed.apk
+  testAppsFeedName: Engineering/BrokerE2ETestApps
   
 parameters:
 - name: firebaseDeviceIdHigh
@@ -241,8 +242,7 @@ stages:
   jobs:
     - template: ./templates/download-old-test-apps.yml
       parameters:
-        feedName: '$(msazureFeedName)'
-        serviceConnection: '$(msazureServiceConnection)'
+        feedName: '$(testAppsFeedName)'
         oldMsalTestAppVersion: ${{ parameters.oldMsalTestAppVersion }}
         oldOneAuthTestAppVersion: ${{ parameters.oldOneAuthTestAppVersion }}
 # MSAL with Broker Test Plan stage (API 30+)

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -59,6 +59,7 @@ variables:
   LTWApk: LTW-signed.apk
   oldLTWApk: OldLTW-signed.apk
   oneAuthServiceConnection: OneAuth-Integration
+  testAppsFeedName: Engineering/BrokerE2ETestApps
   
 parameters:
 - name: firebaseDeviceIdHigh
@@ -264,8 +265,7 @@ stages:
   jobs:
     - template: ./templates/download-old-test-apps.yml
       parameters:
-        feedName: '$(msazureFeedName)'
-        serviceConnection: '$(msazureServiceConnection)'
+        feedName: '$(testAppsFeedName)'
         oldMsalTestAppVersion: ${{ parameters.oldMsalTestAppVersion }}
         oldOneAuthTestAppVersion: ${{ parameters.oldOneAuthTestAppVersion }}
 # MSAL with Broker Test Plan stage (API 30+)

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -54,7 +54,6 @@ variables:
   LTWFeedName: Auth-Broker-Integrated-LTW-Build
   LTWApk: LTW-signed.apk
   oldLTWApk: OldLTW-signed.apk
-  testAppsFeedName: Engineering/BrokerE2ETestApps
   
 parameters:
 - name: firebaseDeviceIdHigh
@@ -242,7 +241,8 @@ stages:
   jobs:
     - template: ./templates/download-old-test-apps.yml
       parameters:
-        feedName: '$(testAppsFeedName)'
+        feedName: '$(msazureFeedName)'
+        serviceConnection: '$(msazureServiceConnection)'
         oldMsalTestAppVersion: ${{ parameters.oldMsalTestAppVersion }}
         oldOneAuthTestAppVersion: ${{ parameters.oldOneAuthTestAppVersion }}
 # MSAL with Broker Test Plan stage (API 30+)

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -59,7 +59,7 @@ variables:
   LTWApk: LTW-signed.apk
   oldLTWApk: OldLTW-signed.apk
   oneAuthServiceConnection: OneAuth-Integration
-  testAppsFeedName: Engineering/BrokerE2ETestApps
+  testAppsFeedName: AndroidADAL
   
 parameters:
 - name: firebaseDeviceIdHigh
@@ -117,7 +117,7 @@ parameters:
 - name: oldOneAuthTestAppVersion
   displayName: Old OneAuth Test App Version
   type: string
-  default: '0.20230614.1'
+  default: '0.1118843.20854054'
 - name: preInstallLtw
   displayName: Preinstall Link to Windows
   type: boolean

--- a/azure-pipelines/ui-automation/templates/download-old-test-apps.yml
+++ b/azure-pipelines/ui-automation/templates/download-old-test-apps.yml
@@ -1,10 +1,7 @@
 parameters:
   - name: feedName
     type: string
-    default: 'AndroidBroker-Broker'
-  - name: serviceConnection
-    type: string
-    default: 'AndroidBroker-CI'
+    default: 'Engineering/BrokerE2ETestApps'
   - name: oldMsalTestAppVersion
     displayName: Old MSAL Test App Version
     type: string
@@ -29,21 +26,19 @@ jobs:
         inputs:
           command: 'download'
           downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldtestapps'
-          feedsToUse: 'external'
-          externalFeedCredentials: '${{ parameters.serviceConnection }}'
-          feedDownloadExternal: '${{ parameters.feedName }}'
-          packageDownloadExternal: 'com.microsoft.identity.client.testapp'
-          versionDownloadExternal: '${{ parameters.oldMsalTestAppVersion }}'
+          feedsToUse: 'internal'
+          vstsFeed: '${{ parameters.feedName }}'
+          vstsFeedPackage: 'com.microsoft.identity.client.testapp'
+          vstsPackageVersion: '${{ parameters.oldMsalTestAppVersion }}'
       - task: UniversalPackages@0
         displayName: 'Download Old OneAuth Test App Apk'
         inputs:
           command: 'download'
           downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldtestapps'
-          feedsToUse: 'external'
-          externalFeedCredentials: '${{ parameters.serviceConnection }}'
-          feedDownloadExternal: '${{ parameters.feedName }}'
-          packageDownloadExternal: 'com.microsoft.oneauth.testapp'
-          versionDownloadExternal: '${{ parameters.oldOneAuthTestAppVersion }}'
+          feedsToUse: 'internal'
+          vstsFeed: '${{ parameters.feedName }}'
+          vstsFeedPackage: 'com.microsoft.oneauth.testapp'
+          vstsPackageVersion: '${{ parameters.oldOneAuthTestAppVersion }}'
       - publish: $(Build.ArtifactStagingDirectory)/oldtestapps
         displayName: 'Publish Old Test App APKs'
         artifact: oldtestapps

--- a/azure-pipelines/ui-automation/templates/download-old-test-apps.yml
+++ b/azure-pipelines/ui-automation/templates/download-old-test-apps.yml
@@ -1,0 +1,44 @@
+parameters:
+  - name: feedName
+    type: string
+    default: 'BrokerE2ETestApps'
+  - name: oldMsalTestAppVersion
+    displayName: Old MSAL Test App Version
+    type: string
+    default: '4.5.0'
+  - name: oldOneAuthTestAppVersion
+    displayName: Old OneAuth Test App Version
+    type: string
+    default: '1.0.0'
+
+jobs:
+  - job: 'download_old_test_apps'
+    displayName: Download Old Test Apps
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      - checkout: none
+      - script: mkdir oldTestApps
+        displayName: 'Make oldTestApps dir'
+        workingDirectory: '$(Build.ArtifactStagingDirectory)'
+      - task: UniversalPackages@0
+        displayName: 'Download Old Msal Test App Apk'
+        inputs:
+          command: 'download'
+          downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldTestApps'
+          feedsToUse: 'internal'
+          vstsFeed: '${{ parameters.feedName }}'
+          vstsFeedPackage: 'com.microsoft.identity.client.testapp'
+          vstsPackageVersion: '${{ parameters.oldMsalTestAppVersion }}'
+      - task: UniversalPackages@0
+        displayName: 'Download Old OneAuth Test App Apk'
+        inputs:
+          command: 'download'
+          downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldTestApps'
+          feedsToUse: 'internal'
+          vstsFeed: '${{ parameters.feedName }}'
+          vstsFeedPackage: 'com.microsoft.oneauth.testapp'
+          vstsPackageVersion: '${{ parameters.oldOneAuthTestAppVersion }}'
+      - publish: $(Build.ArtifactStagingDirectory)/oldTestApps
+        displayName: 'Publish Old Test App APKs'
+        artifact: oldTestApps

--- a/azure-pipelines/ui-automation/templates/download-old-test-apps.yml
+++ b/azure-pipelines/ui-automation/templates/download-old-test-apps.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: feedName
     type: string
-    default: 'BrokerE2ETestApps'
+    default: 'Engineering/BrokerE2ETestApps'
   - name: oldMsalTestAppVersion
     displayName: Old MSAL Test App Version
     type: string

--- a/azure-pipelines/ui-automation/templates/download-old-test-apps.yml
+++ b/azure-pipelines/ui-automation/templates/download-old-test-apps.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: feedName
     type: string
-    default: 'Engineering/BrokerE2ETestApps'
+    default: 'AndroidADAL'
   - name: oldMsalTestAppVersion
     displayName: Old MSAL Test App Version
     type: string
@@ -9,7 +9,7 @@ parameters:
   - name: oldOneAuthTestAppVersion
     displayName: Old OneAuth Test App Version
     type: string
-    default: '0.20230614.1'
+    default: '0.1118843.20854054'
 
 jobs:
   - job: 'download_old_test_apps'

--- a/azure-pipelines/ui-automation/templates/download-old-test-apps.yml
+++ b/azure-pipelines/ui-automation/templates/download-old-test-apps.yml
@@ -9,7 +9,7 @@ parameters:
   - name: oldOneAuthTestAppVersion
     displayName: Old OneAuth Test App Version
     type: string
-    default: '1.0.0'
+    default: '0.20230614.1'
 
 jobs:
   - job: 'download_old_test_apps'

--- a/azure-pipelines/ui-automation/templates/download-old-test-apps.yml
+++ b/azure-pipelines/ui-automation/templates/download-old-test-apps.yml
@@ -25,7 +25,7 @@ jobs:
         displayName: 'Download Old Msal Test App Apk'
         inputs:
           command: 'download'
-          downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldTestApps'
+          downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldtestapps'
           feedsToUse: 'internal'
           vstsFeed: '${{ parameters.feedName }}'
           vstsFeedPackage: 'com.microsoft.identity.client.testapp'
@@ -34,11 +34,11 @@ jobs:
         displayName: 'Download Old OneAuth Test App Apk'
         inputs:
           command: 'download'
-          downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldTestApps'
+          downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldtestapps'
           feedsToUse: 'internal'
           vstsFeed: '${{ parameters.feedName }}'
           vstsFeedPackage: 'com.microsoft.oneauth.testapp'
           vstsPackageVersion: '${{ parameters.oldOneAuthTestAppVersion }}'
-      - publish: $(Build.ArtifactStagingDirectory)/oldTestApps
+      - publish: $(Build.ArtifactStagingDirectory)/oldtestapps
         displayName: 'Publish Old Test App APKs'
-        artifact: oldTestApps
+        artifact: oldtestapps

--- a/azure-pipelines/ui-automation/templates/download-old-test-apps.yml
+++ b/azure-pipelines/ui-automation/templates/download-old-test-apps.yml
@@ -1,7 +1,10 @@
 parameters:
   - name: feedName
     type: string
-    default: 'Engineering/BrokerE2ETestApps'
+    default: 'AndroidBroker-Broker'
+  - name: serviceConnection
+    type: string
+    default: 'AndroidBroker-CI'
   - name: oldMsalTestAppVersion
     displayName: Old MSAL Test App Version
     type: string
@@ -26,19 +29,21 @@ jobs:
         inputs:
           command: 'download'
           downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldtestapps'
-          feedsToUse: 'internal'
-          vstsFeed: '${{ parameters.feedName }}'
-          vstsFeedPackage: 'com.microsoft.identity.client.testapp'
-          vstsPackageVersion: '${{ parameters.oldMsalTestAppVersion }}'
+          feedsToUse: 'external'
+          externalFeedCredentials: '${{ parameters.serviceConnection }}'
+          feedDownloadExternal: '${{ parameters.feedName }}'
+          packageDownloadExternal: 'com.microsoft.identity.client.testapp'
+          versionDownloadExternal: '${{ parameters.oldMsalTestAppVersion }}'
       - task: UniversalPackages@0
         displayName: 'Download Old OneAuth Test App Apk'
         inputs:
           command: 'download'
           downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldtestapps'
-          feedsToUse: 'internal'
-          vstsFeed: '${{ parameters.feedName }}'
-          vstsFeedPackage: 'com.microsoft.oneauth.testapp'
-          vstsPackageVersion: '${{ parameters.oldOneAuthTestAppVersion }}'
+          feedsToUse: 'external'
+          externalFeedCredentials: '${{ parameters.serviceConnection }}'
+          feedDownloadExternal: '${{ parameters.feedName }}'
+          packageDownloadExternal: 'com.microsoft.oneauth.testapp'
+          versionDownloadExternal: '${{ parameters.oldOneAuthTestAppVersion }}'
       - publish: $(Build.ArtifactStagingDirectory)/oldtestapps
         displayName: 'Publish Old Test App APKs'
         artifact: oldtestapps


### PR DESCRIPTION
Add parameters to the “Android Broker CI” pipeline to pass old versions of MsalTestApp and OneAuthTestApp. 

Add file paths of old version test app apks to the following stages: 

msal_with_broker_high_api in the broker-test.yml file 

msal_with_brokerhost_high_api in the broker-test.yml file 

msal_with_broker_low_api in the broker-test.yml file 