### PR TITLE
Added a pipeline parameter to add a broker selection flag

### DIFF
--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -83,7 +83,7 @@ variables:
   brokerAutomationPipelineId: 1490
   ${{ if parameters.shouldEnableBrokerSelectionFlag }}:
     enableBrokerSelectionParam: -PbrokerSelectionEnabledFlag
-  $ {{ else }}:
+  ${{ else }}:
     enableBrokerSelectionParam: ''
 
 stages:

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -53,8 +53,8 @@ parameters:
     displayName: Publish Libraries?
     type: boolean
     default: True
-  - name: shouldEnableBrokerSelectionFlag
-    displayName: Should enable broker selection?
+  - name: shouldEnableBrokerSelectionAndDiscoveryFlag
+    displayName: Should enable broker selection & discovery?
     type: boolean
     default: False
   - name: msalTestTarget
@@ -83,8 +83,10 @@ variables:
   brokerAutomationPipelineId: 1490
   ${{ if parameters.shouldEnableBrokerSelectionFlag }}:
     enableBrokerSelectionParam: -PbrokerSelectionEnabledFlag
+    enableBrokerDiscoveryParam: -PnewBrokerDiscoveryEnabledFlag
   ${{ else }}:
     enableBrokerSelectionParam: ''
+    enableBrokerDiscoveryParam: ''
 
 stages:
 # Common4j - Build and publish
@@ -118,7 +120,7 @@ stages:
       publishCmd: publishDistReleasePublicationToVsts-maven-adal-androidRepository
       dependencyParams:  $(common4jVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam)
-      testParams: $(projVersionParam) $(common4jVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
+      testParams: $(projVersionParam) $(common4jVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true $(enableBrokerDiscoveryParam)
       publishParams: $(projVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -98,7 +98,7 @@ stages:
       project: common4j
       testCmd: common4jUnitTestCoverageReport
       dependencyParams: $(javaProjectDependencyParam)
-      assembleParams: $(projVersionParam) $(enableBrokerSelectionParam)
+      assembleParams: $(projVersionParam)
       testParams: $(projVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
       publishParams: $(projVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
@@ -161,8 +161,8 @@ stages:
       testCmd: distDebugAADAuthenticatorUnitTestCoverageReport
       publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
-      assembleParams: -PprojVersion=$(brokerVersionNumber) $(broker4jVersionParam) $(commonVersionParam) $(powerLiftApiKeyParam)
-      testParams: -PprojVersion=$(brokerVersionNumber) $(broker4jVersionParam) $(commonVersionParam) $(powerLiftApiKeyParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
+      assembleParams: -PprojVersion=$(brokerVersionNumber) $(broker4jVersionParam) $(commonVersionParam) $(powerLiftApiKeyParam) $(enableBrokerSelectionParam)
+      testParams: -PprojVersion=$(brokerVersionNumber) $(broker4jVersionParam) $(commonVersionParam) $(powerLiftApiKeyParam) $(enableBrokerSelectionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
       publishParams: -PprojVersion=$(brokerVersionNumber) $(broker4jVersionParam) $(commonVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -119,7 +119,7 @@ stages:
       testCmd: distDebugCommonUnitTestCoverageReport
       publishCmd: publishDistReleasePublicationToVsts-maven-adal-androidRepository
       dependencyParams:  $(common4jVersionParam) $(androidProjectDependencyParam)
-      assembleParams: $(projVersionParam) $(common4jVersionParam)
+      assembleParams: $(projVersionParam) $(common4jVersionParam) $(enableBrokerDiscoveryParam)
       testParams: $(projVersionParam) $(common4jVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true $(enableBrokerDiscoveryParam)
       publishParams: $(projVersionParam) $(common4jVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -81,7 +81,7 @@ variables:
   androidProjectDependencyParam: --configuration=distReleaseRuntimeClasspath --write-locks
   javaProjectDependencyParam: --configuration=runtimeClasspath --write-locks
   brokerAutomationPipelineId: 1490
-  ${{ if parameters.shouldEnableBrokerSelectionFlag }}:
+  ${{ if parameters.shouldEnableBrokerSelectionAndDiscoveryFlag }}:
     enableBrokerSelectionParam: -PbrokerSelectionEnabledFlag
     enableBrokerDiscoveryParam: -PnewBrokerDiscoveryEnabledFlag
   ${{ else }}:

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -53,6 +53,10 @@ parameters:
     displayName: Publish Libraries?
     type: boolean
     default: True
+  - name: shouldEnableBrokerSelectionFlag
+    displayName: Should enable broker selection?
+    type: boolean
+    default: False
   - name: msalTestTarget
     displayName: Test Targets for MSAL
     type: string
@@ -77,6 +81,10 @@ variables:
   androidProjectDependencyParam: --configuration=distReleaseRuntimeClasspath --write-locks
   javaProjectDependencyParam: --configuration=runtimeClasspath --write-locks
   brokerAutomationPipelineId: 1490
+  ${{ if parameters.shouldEnableBrokerSelectionFlag }}:
+    enableBrokerSelectionParam: -PbrokerSelectionEnabledFlag
+  $ {{ else }}:
+    enableBrokerSelectionParam: ''
 
 stages:
 # Common4j - Build and publish
@@ -90,7 +98,7 @@ stages:
       project: common4j
       testCmd: common4jUnitTestCoverageReport
       dependencyParams: $(javaProjectDependencyParam)
-      assembleParams: $(projVersionParam)
+      assembleParams: $(projVersionParam) $(enableBrokerSelectionParam)
       testParams: $(projVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
       publishParams: $(projVersionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME


### PR DESCRIPTION
Currently, to enable the broker selection flag, we have a static variable that broker host apps can use to set it as true. But we also want a compile time flag that can enable the broker selection logic. And also to be able to enable it from the pipeline.

<img width="355" alt="image" src="https://github.com/AzureAD/android-complete/assets/69237821/98ceac85-ac9d-4f01-91ef-2752cbdf271a">


Testing
1. By checking the above "should enable broker selection flag?" box -- pipeline run with the flag passed in assemble stage. -> [Pipelines - Run 0.0.20230621-dev.7 logs (visualstudio.com)](https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1121700&view=logs&j=b9253adc-4b7c-5a30-2405-c3bdf5ef398f&t=34794a0a-0392-530d-0fa5-13944baf38e0)
2. By unchecking the above "should enable broker selection flag?" box -- pipeline run with the flag NOT passed in assemble stage -> [Pipelines - Run 0.0.20230621-dev.6 logs (visualstudio.com)](https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1121697&view=logs&j=b9253adc-4b7c-5a30-2405-c3bdf5ef398f&t=34794a0a-0392-530d-0fa5-13944baf38e0)

Note : Modified the same build to also set new broker discovery flag in common 
build with flag enabled - https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1121855&view=logs&j=b9253adc-4b7c-5a30-2405-c3bdf5ef398f&t=34794a0a-0392-530d-0fa5-13944baf38e0

