### PR TITLE
[WIP] Add old brokerhost to monthly relase pipeline

### DIFF
--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -574,8 +574,6 @@ stages:
 # Download Brokers
 - stage: 'download_brokers'
   dependsOn:
-  - queueAuthenticatorBrokerApkPipeline
-  - queueCompanyPortalBrokerApkPipeline
   - testappgeneration
   displayName: Download PROD & RC Brokers
   condition:

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -579,7 +579,6 @@ stages:
   condition:
     and
     (
-      not(failed()),
       not(canceled())
     )
   jobs:

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -576,11 +576,7 @@ stages:
   dependsOn:
   - testappgeneration
   displayName: Download PROD & RC Brokers
-  condition:
-    and
-    (
-      not(canceled())
-    )
+  condition: not(canceled())
   jobs:
     - template: ./templates/download-brokers.yml
       parameters:

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -748,6 +748,7 @@ stages:
         otherFiles: "/sdcard/CompanyPortal.apk=$(Pipeline.Workspace)/brokerapks/$(companyPortalApk),\
                           /sdcard/Authenticator.apk=$(Pipeline.Workspace)/brokerapks/$(authenticatorApk),\
                           /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
+                          /sdcard/OldBrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/brokerHost-local-debug.apk,\
                           /sdcard/AzureSample.apk=$(Pipeline.Workspace)/AzureSample-PROD/AzureSample-external-release.apk,\
                           /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/BrokerHost-Local-RC-debug/brokerHost-local-debug.apk,\
                           /sdcard/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -574,9 +574,16 @@ stages:
 # Download Brokers
 - stage: 'download_brokers'
   dependsOn:
+  - queueAuthenticatorBrokerApkPipeline
+  - queueCompanyPortalBrokerApkPipeline
   - testappgeneration
   displayName: Download PROD & RC Brokers
-  condition: not(canceled())
+  condition:
+    and
+    (
+      not(failed()),
+      not(canceled())
+    )
   jobs:
     - template: ./templates/download-brokers.yml
       parameters:

--- a/azure-pipelines/ui-automation/templates/download-brokers.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers.yml
@@ -25,6 +25,10 @@ parameters:
   - name: internalFeedName
     type: string
     default: 'AndroidAdal'
+  - name: oldBrokerHostVersion
+    displayName: Old Broker host Version
+    type: string
+    default: '0.0.1'
 
 jobs:
 - job: 'download_brokers'
@@ -94,6 +98,16 @@ jobs:
         vstsFeed: '${{ parameters.internalFeedName }}'
         vstsFeedPackage: 'com.microsoft.identity.testuserapp.prod'
         vstsPackageVersion: '${{ parameters.prodBrokerHostVersion }}'
+    - task: UniversalPackages@0
+      displayName: 'Download old brokerHost version from feed'
+      inputs:
+        command: 'download'
+        downloadDirectory: '$(Build.ArtifactStagingDirectory)/brokers/oldAPKs'
+        feedsToUse: 'external'
+        externalFeedCredentials: '${{ parameters.msazureServiceConnection }}'
+        feedDownloadExternal: '${{ parameters.msazureFeedName }}'
+        packageDownloadExternal: 'broker-host'
+        versionDownloadExternal: '${{ parameters.oldBrokerHostVersion }}'
     - publish: $(Build.ArtifactStagingDirectory)/brokers
       displayName: 'Publish Broker apks for later use'
       artifact: brokerapks


### PR DESCRIPTION
The next test https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2563668
requires an instance of the old broker host, so 
1. we are getting this APK in azure-pipelines/ui-automation/templates/download-brokers.yml
2. we are passing this APK the task that executes this test in the monthly release pipeline.