### PR TITLE
Passing common version to Android CI pipeline

### DIFF
--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -391,7 +391,7 @@ stages:
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId $(brokerAutomationPipelineId) -BuildIdOutputVar "brokerAutomationBuildId" -Branch "$(Build.SourceBranch)" -PipelineVariablesJson "{ ''msalTestTarget'' : ''${{ parameters.msalTestTarget }}'' , ''commonVersion'' : ''$(versionNumber)'' ''brokerTestTarget'' : ''${{ parameters.brokerTestTarget }}'', ''msal_sdk_version'': ''$(versionNumber)'' }"'
+            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId $(brokerAutomationPipelineId) -BuildIdOutputVar "brokerAutomationBuildId" -Branch "$(Build.SourceBranch)" -PipelineVariablesJson "{ ''msalTestTarget'' : ''${{ parameters.msalTestTarget }}'' , ''commonVersion'' : ''$(versionNumber)'', ''brokerTestTarget'' : ''${{ parameters.brokerTestTarget }}'', ''msal_sdk_version'': ''$(versionNumber)'' }"'
             workingDirectory: '$(Build.SourcesDirectory)'
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -121,7 +121,7 @@ stages:
       dependencyParams:  $(common4jVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam) $(enableBrokerDiscoveryParam)
       testParams: $(projVersionParam) $(common4jVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true $(enableBrokerDiscoveryParam)
-      publishParams: $(projVersionParam) $(common4jVersionParam)
+      publishParams: $(projVersionParam) $(common4jVersionParam) $(enableBrokerDiscoveryParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -391,7 +391,7 @@ stages:
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId $(brokerAutomationPipelineId) -BuildIdOutputVar "brokerAutomationBuildId" -Branch "somalaya/passCommonVersionToOneAuth" -PipelineVariablesJson "{ ''msalTestTarget'' : ''${{ parameters.msalTestTarget }}'' , ''commonVersion'' : ''$(versionNumber)'', ''brokerTestTarget'' : ''${{ parameters.brokerTestTarget }}'', ''msal_sdk_version'': ''$(versionNumber)'' }"'
+            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId $(brokerAutomationPipelineId) -BuildIdOutputVar "brokerAutomationBuildId" -Branch  "$(Build.SourceBranch)" -PipelineVariablesJson "{ ''msalTestTarget'' : ''${{ parameters.msalTestTarget }}'' , ''commonVersion'' : ''$(versionNumber)'', ''brokerTestTarget'' : ''${{ parameters.brokerTestTarget }}'', ''msal_sdk_version'': ''$(versionNumber)'' }"'
             workingDirectory: '$(Build.SourcesDirectory)'
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -391,7 +391,7 @@ stages:
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId $(brokerAutomationPipelineId) -BuildIdOutputVar "brokerAutomationBuildId" -Branch "$(Build.SourceBranch)" -PipelineVariablesJson "{ ''msalTestTarget'' : ''${{ parameters.msalTestTarget }}'' , ''commonVersion'' : ''$(versionNumber)'', ''brokerTestTarget'' : ''${{ parameters.brokerTestTarget }}'', ''msal_sdk_version'': ''$(versionNumber)'' }"'
+            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId $(brokerAutomationPipelineId) -BuildIdOutputVar "brokerAutomationBuildId" -Branch "somalaya/passCommonVersionToOneAuth" -PipelineVariablesJson "{ ''msalTestTarget'' : ''${{ parameters.msalTestTarget }}'' , ''commonVersion'' : ''$(versionNumber)'', ''brokerTestTarget'' : ''${{ parameters.brokerTestTarget }}'', ''msal_sdk_version'': ''$(versionNumber)'' }"'
             workingDirectory: '$(Build.SourcesDirectory)'
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -117,7 +117,7 @@ stages:
       project: common
       assembleCmd: assembleDist
       testCmd: distDebugCommonUnitTestCoverageReport
-      publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
+      publishCmd: publish
       dependencyParams:  $(common4jVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam) $(enableBrokerDiscoveryParam)
       testParams: $(projVersionParam) $(common4jVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true $(enableBrokerDiscoveryParam)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -391,7 +391,7 @@ stages:
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId $(brokerAutomationPipelineId) -BuildIdOutputVar "brokerAutomationBuildId" -Branch "$(Build.SourceBranch)" -PipelineVariablesJson "{ ''msalTestTarget'' : ''${{ parameters.msalTestTarget }}'' , ''brokerTestTarget'' : ''${{ parameters.brokerTestTarget }}'', ''msal_sdk_version'': ''$(versionNumber)'' }"'
+            arguments: '-OrganizationUrl "https://identitydivision.visualstudio.com/" -Project "Engineering" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -BuildDefinitionId $(brokerAutomationPipelineId) -BuildIdOutputVar "brokerAutomationBuildId" -Branch "$(Build.SourceBranch)" -PipelineVariablesJson "{ ''msalTestTarget'' : ''${{ parameters.msalTestTarget }}'' , ''commonVersion'' : ''$(versionNumber)'' ''brokerTestTarget'' : ''${{ parameters.brokerTestTarget }}'', ''msal_sdk_version'': ''$(versionNumber)'' }"'
             workingDirectory: '$(Build.SourcesDirectory)'
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -117,7 +117,7 @@ stages:
       project: common
       assembleCmd: assembleDist
       testCmd: distDebugCommonUnitTestCoverageReport
-      publishCmd: publishDistReleasePublicationToVsts-maven-adal-androidRepository
+      publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
       dependencyParams:  $(common4jVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam) $(enableBrokerDiscoveryParam)
       testParams: $(projVersionParam) $(common4jVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true $(enableBrokerDiscoveryParam)

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -312,7 +312,7 @@ stages:
       project: AADAuthenticator
       testCmd: distDebugAADAuthenticatorUnitTestCoverageReport
       assembleCmd: assembleDist
-      publishCmd: publish
+      publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(adAccountsProjVersionParam) $(broker4jVersionParam) $(commonVersionParam) $(brokerOtelAriaTokenParam) $(powerLiftApiKeyParam)
       testParams: $(adAccountsProjVersionParam) $(broker4jVersionParam) $(commonVersionParam) $(powerLiftApiKeyParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -312,7 +312,7 @@ stages:
       project: AADAuthenticator
       testCmd: distDebugAADAuthenticatorUnitTestCoverageReport
       assembleCmd: assembleDist
-      publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
+      publishCmd: publish
       dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(adAccountsProjVersionParam) $(broker4jVersionParam) $(commonVersionParam) $(brokerOtelAriaTokenParam) $(powerLiftApiKeyParam)
       testParams: $(adAccountsProjVersionParam) $(broker4jVersionParam) $(commonVersionParam) $(powerLiftApiKeyParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true


### PR DESCRIPTION
1. Made changes to pass currently built common version to Android CI pipeline
2. Changed the publish cmd in common to publish the all build variants. This is required because OneAuthTestApp pipeline looks for common version from common-debug feed for one of their build variants.