### PR TITLE
Remove PROD brokerhost step, push RC Dist version to feed

### DIFF
--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -509,6 +509,7 @@ stages:
         adAccountsVersion: ${{ parameters.adAccountsVersionRC }}
         adalVersion: ${{ parameters.adalVersionRC }}
         packageVariant: RC
+        publishToProdFeed: True
     - template: ./templates/build-broker-host.yml
       parameters:
         productFlavors: Local

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -124,6 +124,10 @@ parameters:
   displayName: Broker Branch
   type: string
   default: 'dev'
+- name: prodBrokerBranch
+  displayName: PROD Broker Branch
+  type: string
+  default: 'dev'
 
 resources:
   repositories:
@@ -136,6 +140,11 @@ resources:
     type: github
     name: AzureAD/ad-accounts-for-android
     ref: ${{ parameters.brokerBranch }}
+    endpoint: ANDROID_GITHUB
+  - repository: broker-prod
+    type: github
+    name: AzureAD/ad-accounts-for-android
+    ref: ${{ parameters.prodBrokerBranch }}
     endpoint: ANDROID_GITHUB
   - repository: azuresample
     type: github
@@ -500,6 +509,7 @@ stages:
         signingConfigurations: Release
         msalVersion: ${{ parameters.msalVersionPROD }}
         packageVariant: PROD
+        brokerBranch: broker-prod
     - template: ./templates/build-broker-host.yml
       parameters:
         productFlavors: Dist

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -509,7 +509,6 @@ stages:
         signingConfigurations: Release
         msalVersion: ${{ parameters.msalVersionPROD }}
         packageVariant: PROD
-        brokerBranch: broker-prod
     - template: ./templates/build-broker-host.yml
       parameters:
         productFlavors: Dist
@@ -519,6 +518,7 @@ stages:
         adAccountsVersion: ${{ parameters.adAccountsVersionPROD }}
         adalVersion: ${{ parameters.adalVersionPROD }}
         packageVariant: PROD
+        brokerBranch: broker-prod
     - template: ./templates/build-broker-host.yml
       parameters:
         productFlavors: Dist

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -124,10 +124,6 @@ parameters:
   displayName: Broker Branch
   type: string
   default: 'dev'
-- name: prodBrokerBranch
-  displayName: PROD Broker Branch
-  type: string
-  default: 'dev'
 
 resources:
   repositories:
@@ -513,16 +509,6 @@ stages:
       parameters:
         productFlavors: Dist
         signingConfigurations: Release
-        msalVersion: ${{ parameters.msalVersionPROD }}
-        commonVersion: ${{ parameters.commonVersionPROD }}
-        adAccountsVersion: ${{ parameters.adAccountsVersionPROD }}
-        adalVersion: ${{ parameters.adalVersionPROD }}
-        packageVariant: PROD
-        brokerBranch: broker-prod
-    - template: ./templates/build-broker-host.yml
-      parameters:
-        productFlavors: Dist
-        signingConfigurations: Release
         msalVersion: ${{ parameters.msalVersionRC }}
         commonVersion: ${{ parameters.commonVersionRC }}
         adAccountsVersion: ${{ parameters.adAccountsVersionRC }}
@@ -605,7 +591,7 @@ stages:
         oldAuthenticatorVersion: $(oldAuthenticatorVersion)
         companyPortalVersionRC: $(rcCompanyPortalVersion)
         companyPortalVersionPROD: ${{ parameters.prodCompanyPortalVersion }}
-        prodBrokerHostVersion: $(prodBrokerHostVersion)
+        prodBrokerHostVersion: ${{ parameters.adAccountsVersionPROD}}
 
 # ADAL with Broker (API 30+)
 - stage: 'adal_with_broker_high_api'

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -137,11 +137,6 @@ resources:
     name: AzureAD/ad-accounts-for-android
     ref: ${{ parameters.brokerBranch }}
     endpoint: ANDROID_GITHUB
-  - repository: broker-prod
-    type: github
-    name: AzureAD/ad-accounts-for-android
-    ref: ${{ parameters.prodBrokerBranch }}
-    endpoint: ANDROID_GITHUB
   - repository: azuresample
     type: github
     name: Azure-Samples/ms-identity-android-java

--- a/azure-pipelines/ui-automation/templates/build-broker-host.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-host.yml
@@ -25,6 +25,10 @@ parameters:
 - name: msalVersion
   displayName: MSAL Version
   type: string
+- name: brokerBranch
+  displayName: Broker Branch alias
+  type: string
+  default: broker
 - name: packageVariant
   displayName: Package Variant
   type: string
@@ -55,7 +59,7 @@ jobs:
     clean: true
     submodules: true
     path: android-complete/adal
-  - checkout: broker
+  - checkout: ${{ parameters.brokerBranch }}
     clean: true
     submodules: true
     path: android-complete/broker

--- a/azure-pipelines/ui-automation/templates/build-broker-host.yml
+++ b/azure-pipelines/ui-automation/templates/build-broker-host.yml
@@ -25,10 +25,10 @@ parameters:
 - name: msalVersion
   displayName: MSAL Version
   type: string
-- name: brokerBranch
-  displayName: Broker Branch alias
-  type: string
-  default: broker
+- name: publishToProdFeed
+  displayName: Publish to Prod Feed?
+  type: boolean
+  default: False
 - name: packageVariant
   displayName: Package Variant
   type: string
@@ -59,7 +59,7 @@ jobs:
     clean: true
     submodules: true
     path: android-complete/adal
-  - checkout: ${{ parameters.brokerBranch }}
+  - checkout: broker
     clean: true
     submodules: true
     path: android-complete/broker
@@ -118,7 +118,7 @@ jobs:
       targetPath: $(Agent.BuildDirectory)/android-complete/broker/userapp/build/outputs/apk/${{ lower(parameters.productFlavors) }}/${{ lower(parameters.signingConfigurations) }}
       artifactName: BrokerHost-${{ parameters.productFlavors }}-${{ upper(parameters.packageVariant) }}-${{ lower(parameters.signingConfigurations) }}
       patterns: '**/*.apk'
-  - ${{ if eq(parameters.packageVariant, 'PROD') }}:
+  - ${{ if eq(parameters.publishToProdFeed, 'True') }}:
       - task: UniversalPackages@0
         displayName: Publishing PROD Brokerhost
         continueOnError: true


### PR DESCRIPTION
This Pr fixes the Prod Brokerhost step that caused some issues last release.

Instead of attempting to generate prod brokerhost in every run, we instead push the RC Dist version to feed with the RC broker version used as the feed version. This means we can simply pull it in the next run as the PROD brokerhost. This way, we avoid the issue of using the incorrect broker branch while building with PROD versions (this caused an issue in the past in case changes were made in dev that didn't align with the PROD versions).

Succesful release pipeline run
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1126084&view=results