### PR TITLE
Pass common version to one auth

### DIFF
--- a/azure-pipelines/scripts/queue-build.ps1
+++ b/azure-pipelines/scripts/queue-build.ps1
@@ -4,6 +4,7 @@ Param (
     [Parameter(Mandatory = $true)][String]$PipelinePAT,
     [Parameter(Mandatory = $true)][String]$BuildDefinitionId,
     [Parameter(Mandatory = $false)][String]$PipelineVariablesJson,
+    [Parameter(Mandatory = $false)][String]$TemplateParams,
     [Parameter(Mandatory = $false)][String]$Branch,
     [Parameter(Mandatory = $false)][int]$WaitTimeoutInMinutes = 120,
     [Parameter(Mandatory = $false)][int]$PollingIntervalInSeconds = 5 * 60,
@@ -27,6 +28,7 @@ $Build = New-Object PSObject -Property @{
         sourceBranch = $Branch
         reason = "userCreated"
         parameters = $PipelineVariablesJson
+        templateParameters = $TemplateParams | ConvertFrom-Json
     }
 
 $requestBody = $Build | ConvertTo-Json

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -218,7 +218,7 @@ stages:
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$(OfficePAT)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -TemplateParams "{''androidCommonVersion'': ''$commonVersion''}"'
+            arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$(OfficePAT)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -TemplateParams "{''androidCommonVersion'': ''$(commonVersion)''}"'
             workingDirectory: '$(Build.SourcesDirectory)'
         - task: DownloadExternalBuildArtifacts@15
           displayName: 'Download OneAuth test app'

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -60,7 +60,6 @@ variables:
   oldLTWApk: OldLTW-signed.apk
   oneAuthServiceConnection: OneAuth-Integration
   testAppsFeedName: AndroidADAL
-  commonVersion: '13.0.1'
   
 parameters:
 - name: firebaseDeviceIdHigh

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -60,6 +60,7 @@ variables:
   oldLTWApk: OldLTW-signed.apk
   oneAuthServiceConnection: OneAuth-Integration
   testAppsFeedName: AndroidADAL
+  commonVersion: '13.0.1'
   
 parameters:
 - name: firebaseDeviceIdHigh
@@ -218,7 +219,7 @@ stages:
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$(OfficePAT)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)"'
+            arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$(OfficePAT)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -TemplateParams "{''androidCommonVersion'': ''$commonVersion''}"'
             workingDirectory: '$(Build.SourcesDirectory)'
         - task: DownloadExternalBuildArtifacts@15
           displayName: 'Download OneAuth test app'


### PR DESCRIPTION
To build oneAUth test app, we are triggering OneAuthTestApp pipeline from the Android CI pipeline. But previously, we were not passing the latest common version to be used while building OneAuthTestApp. With this change, we pass the common version to OneAuthTestApp pipeline.