### PR TITLE
Update Old Msal Test App version and OneAuth integration branch

### DIFF
--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -218,7 +218,7 @@ stages:
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$(OfficePAT)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -Branch "android/common-ingest-2023-07" -TemplateParams "{''androidCommonVersion'': ''$(commonVersion)''}"'
+            arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$(OfficePAT)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -Branch "android/common-ingestion" -TemplateParams "{''androidCommonVersion'': ''$(commonVersion)''}"'
             workingDirectory: '$(Build.SourcesDirectory)'
         - task: DownloadExternalBuildArtifacts@15
           displayName: 'Download OneAuth test app'

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -113,7 +113,7 @@ parameters:
 - name: oldMsalTestAppVersion
   displayName: Old MSAL Test App Version
   type: string
-  default: '4.5.0'
+  default: '4.5.1'
 - name: oldOneAuthTestAppVersion
   displayName: Old OneAuth Test App Version
   type: string


### PR DESCRIPTION
We were having some failures in broker ci pipeline, turns out the "old" MSAL Test App version used was pointing to a local debug build, updated this to point to a dist release build instead, and updated the integration branch for oneauth as the old one was deleted.