### PR TITLE
Modified target and compileSDK versions

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -4,8 +4,9 @@ ext {
     minSdkVersion = 16
     brokerProjectMinSdkVersion = 24
     automationAppMinSDKVersion = 21
-    targetSdkVersion = 30
-    compileSdkVersion = 30
+    targetSdkVersion = 34
+    compileSdkVersion = 34
+    automationAndTestAppCompileSDK = 33
     buildToolsVersion = "28.0.3"
 
     // Plugins
@@ -67,7 +68,7 @@ ext {
     javaAssistVersion = "3.27.0-GA"
     yubikitAndroidVersion = "2.3.0"
     yubikitPivVersion = "2.3.0"
-    powerliftAndroidVersion="1.0.1"
+    powerliftAndroidVersion="1.0.3"
 
     // microsoft-diagnostics-uploader app versions
     powerliftVersion = "0.14.7"


### PR DESCRIPTION
- Increasing the targetSDK and compileSDK to 34
- After increasing the targetSDK, it gave some errors like exported attribute must be added when there is an intent filter. So I added that.
- PowerliftSDK version to the latest '1.0.3' as this one has fixes for target and compile sdk to be 34.