### PR TITLE
Add task to generate sbom manifest for daily and monthly pipeline

### DIFF
--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -73,6 +73,20 @@ jobs:
   - task: ComponentGovernanceComponentDetection@0
     inputs:
       sourceScanPath: $(Build.SourcesDirectory)/${{ parameters.project }}/gradle/dependency-locks/
+  - task: ManifestGeneratorTask@0
+    displayName: 'Generate SBOM manifest file'
+    inputs:
+      BuildDropPath: $(Build.SourcesDirectory)/${{ parameters.project }}/build/
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish Artifact: dependencies lockfile'
+    inputs:
+      targetPath: $(Build.SourcesDirectory)/${{ parameters.project }}/gradle/dependency-locks
+      ArtifactName: ${{ parameters.project }}_dependencies
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish Artifact: ${{ parameters.project }} Release'
+    inputs:
+      TargetPath:  $(Build.SourcesDirectory)/${{ parameters.project }}/build/
+      ArtifactName: ${{ parameters.project }}_Release
 - job: RunUnitTest${{ parameters.project }}
   displayName: ${{ parameters.project }} UnitTest
   pool:


### PR DESCRIPTION
### What
[Product Backlog Item 2641375: Generate and publish Software Bills of material (SBOM) for AuthClient SDKs as part of monthly release pipeline](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2641375)

### Why
This is part of EO requirements

### How
Added [sbom](https://aka/ms/sbom) generation and publishing task to daily, monthly release assemble&publish template

### Testing
Test Run daily: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1141538&view=results
Test Run monthly: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1141540&view=results