### PR TITLE
Build test apps during daily runs, add msal and adal test apps to release pipeline

### DIFF
--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -26,6 +26,9 @@ parameters:
 - name: shouldRunUnitTests
   type: boolean
   default: True
+- name: shouldRunInstrumentedTests
+  type: boolean
+  default: True
 - name: testParams
   default: ''
   
@@ -139,7 +142,7 @@ jobs:
       inputs:
         summaryFileLocation: '$(Build.SourcesDirectory)/${{ parameters.project }}/build/reports/jacoco/${{ parameters.testCmd }}/${{ parameters.testCmd }}.xml'
         reportDirectory: '$(Build.SourcesDirectory)/${{ parameters.project }}/build/reports/jacoco/${{ parameters.testCmd }}/html'
-- ${{if or(eq(parameters.project, 'common'), eq(parameters.project, 'msal'), eq(parameters.project, 'adal'), eq(parameters.project, 'AADAuthenticator'))}}:
+- ${{if and(eq(parameters.shouldRunInstrumentedTests, 'True'), or(eq(parameters.project, 'common'), eq(parameters.project, 'msal'), eq(parameters.project, 'adal'), eq(parameters.project, 'AADAuthenticator'))}}:
     - template: ../templates/run-instrumented-tests.yml
       parameters:
         gitProject: ${{ parameters.repository }}

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -142,7 +142,7 @@ jobs:
       inputs:
         summaryFileLocation: '$(Build.SourcesDirectory)/${{ parameters.project }}/build/reports/jacoco/${{ parameters.testCmd }}/${{ parameters.testCmd }}.xml'
         reportDirectory: '$(Build.SourcesDirectory)/${{ parameters.project }}/build/reports/jacoco/${{ parameters.testCmd }}/html'
-- ${{if and(eq(parameters.shouldRunInstrumentedTests, 'True'), or(eq(parameters.project, 'common'), eq(parameters.project, 'msal'), eq(parameters.project, 'adal'), eq(parameters.project, 'AADAuthenticator'))}}:
+- ${{if and(eq(parameters.shouldRunInstrumentedTests, 'True'), or(eq(parameters.project, 'common'), eq(parameters.project, 'msal'), eq(parameters.project, 'adal'), eq(parameters.project, 'AADAuthenticator')))}}:
     - template: ../templates/run-instrumented-tests.yml
       parameters:
         gitProject: ${{ parameters.repository }}

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -49,6 +49,10 @@ parameters:
     displayName: Run E2E UI Validation?
     type: boolean
     default: False
+  - name: shouldRunUnitTests
+    displayName: Run Unit Tests?
+    type: boolean
+    default: True
   - name: shouldPublishLibraries
     displayName: Publish Libraries?
     type: boolean
@@ -106,6 +110,7 @@ stages:
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
+      shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
 # Common - Build and publish
 - stage: 'publishCommonLibraries'
   displayName: Common - Build and publish
@@ -125,6 +130,7 @@ stages:
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
+      shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
 # Broker4j - Build and publish
 - stage: 'publishBroke4jLibraries'
   displayName: Broker4j - Build and publish
@@ -144,6 +150,7 @@ stages:
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
+      shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
 # Broker - Build and publish
 - stage: 'publishBrokerLibraries'
   displayName: Android Broker - Build and publish
@@ -170,6 +177,7 @@ stages:
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
       agentImage: 1ES-AndroidPool-EOC
+      shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
 # Linux Broker - Build and publish
 - stage: 'publishLinuxBrokeLibraries'
   displayName: Linux Broker - Build and publish
@@ -190,6 +198,7 @@ stages:
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
       testParams: $(common4jVersionParam) $(broker4jVersionParam) -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
+      shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
   - job: PublishLinuxBrokerPackage
     dependsOn: publishLinuxBrokerLibraries
     displayName: Publish Linux Broker Package
@@ -242,6 +251,7 @@ stages:
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROID_MSAL_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
+      shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
 # Adal - Build and publish
 - stage: 'publishAdal'
   displayName: Adal - Build and publish
@@ -261,6 +271,7 @@ stages:
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADAL_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
+      shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
 
 # Combine and Publish Code Coverage
 - stage: 'combineAndPublishCodeCoverage'
@@ -365,6 +376,56 @@ stages:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
             arguments: '-OrganizationUrl "https://microsoft.visualstudio.com/" -Project "OS" -PipelinePAT "$(OSPAT)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "44201" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(brokerVersionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)'', ''AdalVersion'': ''$(versionNumber)'' }" -Branch "$(LTWBranch)"'
             workingDirectory: '$(Build.SourcesDirectory)'
+
+# TestApp generation
+- stage: 'testappgeneration'
+  dependsOn:
+    - publishAdal
+    - publishCommonLibraries
+    - publishMsal
+    - publishBrokerLibraries
+    - promoteLibraries
+  displayName: Generate Test Apps
+  condition:
+    and
+    (
+    not(failed()),
+    not(canceled())
+    )
+  jobs:
+    - template: ./templates/build-azure-sample-app.yml
+      parameters:
+        productFlavors: Local
+        signingConfigurations: Debug
+        msalVersion: $(versionNumber)
+        packageVariant: RC
+    - template: ./templates/build-azure-sample-app-standalone.yml
+      parameters:
+        signingConfigurations: Debug
+        msalVersion: $(versionNumber)
+        packageVariant: RC
+    - template: ./templates/build-broker-host.yml
+      parameters:
+        productFlavors: Local
+        signingConfigurations: Debug
+        msalVersion: $(versionNumber)
+        commonVersion: $(versionNumber)
+        adAccountsVersion: $(brokerVersionNumber)
+        adalVersion: $(versionNumber)
+        packageVariant: RC
+    - template: ./templates/build-msal-test-app.yml
+      parameters:
+        productFlavors: Dist
+        signingConfigurations: Debug
+        msalVersion: $(versionNumber)
+        packageVariant: RC
+    - template: ./templates/build-adal-test-app.yml
+      parameters:
+        productFlavors: Dist
+        signingConfigurations: Debug
+        commonVersion: $(versionNumber)
+        adalVersion: $(versionNumber)
+        packageVariant: RC
 
 # Broker - E2E Automation
 - stage: 'runBrokerE2EAutomation'

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -393,18 +393,18 @@ stages:
     not(canceled())
     )
   jobs:
-    - template: ../uiautomation/templates/build-azure-sample-app.yml
+    - template: ../ui-automation/templates/build-azure-sample-app.yml
       parameters:
         productFlavors: Local
         signingConfigurations: Debug
         msalVersion: $(versionNumber)
         packageVariant: RC
-    - template: ../uiautomation/templates/build-azure-sample-app-standalone.yml
+    - template: ../ui-automation/templates/build-azure-sample-app-standalone.yml
       parameters:
         signingConfigurations: Debug
         msalVersion: $(versionNumber)
         packageVariant: RC
-    - template: ../uiautomation/templates/build-broker-host.yml
+    - template: ../ui-automation/templates/build-broker-host.yml
       parameters:
         productFlavors: Local
         signingConfigurations: Debug
@@ -413,13 +413,13 @@ stages:
         adAccountsVersion: $(brokerVersionNumber)
         adalVersion: $(versionNumber)
         packageVariant: RC
-    - template: ../uiautomation/templates/build-msal-test-app.yml
+    - template: ../ui-automation/templates/build-msal-test-app.yml
       parameters:
         productFlavors: Dist
         signingConfigurations: Debug
         msalVersion: $(versionNumber)
         packageVariant: RC
-    - template: ../uiautomation/templates/build-adal-test-app.yml
+    - template: ../ui-automation/templates/build-adal-test-app.yml
       parameters:
         productFlavors: Dist
         signingConfigurations: Debug

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -368,7 +368,6 @@ stages:
           persistCredentials: True
         - task: PowerShell@2
           displayName: Queue and wait for Company Portal Apk generation pipeline
-          continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
             arguments: '-OrganizationUrl "https://msazure.visualstudio.com/" -Project "Intune" -PipelinePAT "$(pipelinepat)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "237827" -PipelineVariablesJson "{ ''AdAccountsVersion'': ''$(brokerVersionNumber)'', ''CommonVersion'': ''$(versionNumber)'', ''MsalVersion'': ''$(versionNumber)''}" -Branch "$(companyPortalBranch)"'

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -389,7 +389,7 @@ stages:
     - publishCommonLibraries
     - publishMsal
     - publishBrokerLibraries
-    - promoteLibraries
+    - promotePackages
   displayName: Generate Test Apps
   condition:
     and

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -420,6 +420,7 @@ stages:
         signingConfigurations: Debug
         msalVersion: $(versionNumber)
         packageVariant: RC
+        continueOnError: True
     - template: ../ui-automation/templates/build-broker-host.yml
       parameters:
         productFlavors: Local

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -39,6 +39,11 @@ resources:
       name: AzureAD/azure-activedirectory-library-for-android
       ref: dev
       endpoint: ANDROID_GITHUB
+    - repository: azuresample
+      type: github
+      name: Azure-Samples/ms-identity-android-java
+      ref: master
+      endpoint: ANDROID_GITHUB
 
 parameters:
   - name: customVersionNumber

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -58,6 +58,10 @@ parameters:
     displayName: Run Unit Tests?
     type: boolean
     default: True
+  - name: shouldRunInstrumentedTests
+    displayName: Run Instrumented Tests?
+    type: boolean
+    default: True
   - name: shouldPublishLibraries
     displayName: Publish Libraries?
     type: boolean
@@ -116,6 +120,7 @@ stages:
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
       shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
+      shouldRunInstrumentedTests: ${{ parameters.shouldRunInstrumentedTests }}
 # Common - Build and publish
 - stage: 'publishCommonLibraries'
   displayName: Common - Build and publish
@@ -136,6 +141,7 @@ stages:
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
       shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
+      shouldRunInstrumentedTests: ${{ parameters.shouldRunInstrumentedTests }}
 # Broker4j - Build and publish
 - stage: 'publishBroke4jLibraries'
   displayName: Broker4j - Build and publish
@@ -156,6 +162,7 @@ stages:
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
       shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
+      shouldRunInstrumentedTests: ${{ parameters.shouldRunInstrumentedTests }}
 # Broker - Build and publish
 - stage: 'publishBrokerLibraries'
   displayName: Android Broker - Build and publish
@@ -183,6 +190,7 @@ stages:
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
       agentImage: 1ES-AndroidPool-EOC
       shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
+      shouldRunInstrumentedTests: ${{ parameters.shouldRunInstrumentedTests }}
 # Linux Broker - Build and publish
 - stage: 'publishLinuxBrokeLibraries'
   displayName: Linux Broker - Build and publish
@@ -204,6 +212,7 @@ stages:
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
       testParams: $(common4jVersionParam) $(broker4jVersionParam) -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false --build-cache --info
       shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
+      shouldRunInstrumentedTests: ${{ parameters.shouldRunInstrumentedTests }}
   - job: PublishLinuxBrokerPackage
     dependsOn: publishLinuxBrokerLibraries
     displayName: Publish Linux Broker Package
@@ -257,6 +266,7 @@ stages:
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
       shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
+      shouldRunInstrumentedTests: ${{ parameters.shouldRunInstrumentedTests }}
 # Adal - Build and publish
 - stage: 'publishAdal'
   displayName: Adal - Build and publish
@@ -277,6 +287,7 @@ stages:
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}
       shouldRunUnitTests: ${{ parameters.shouldRunUnitTests }}
+      shouldRunInstrumentedTests: ${{ parameters.shouldRunInstrumentedTests }}
 
 # Combine and Publish Code Coverage
 - stage: 'combineAndPublishCodeCoverage'

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -393,18 +393,18 @@ stages:
     not(canceled())
     )
   jobs:
-    - template: ./templates/build-azure-sample-app.yml
+    - template: ../uiautomation/templates/build-azure-sample-app.yml
       parameters:
         productFlavors: Local
         signingConfigurations: Debug
         msalVersion: $(versionNumber)
         packageVariant: RC
-    - template: ./templates/build-azure-sample-app-standalone.yml
+    - template: ../uiautomation/templates/build-azure-sample-app-standalone.yml
       parameters:
         signingConfigurations: Debug
         msalVersion: $(versionNumber)
         packageVariant: RC
-    - template: ./templates/build-broker-host.yml
+    - template: ../uiautomation/templates/build-broker-host.yml
       parameters:
         productFlavors: Local
         signingConfigurations: Debug
@@ -413,13 +413,13 @@ stages:
         adAccountsVersion: $(brokerVersionNumber)
         adalVersion: $(versionNumber)
         packageVariant: RC
-    - template: ./templates/build-msal-test-app.yml
+    - template: ../uiautomation/templates/build-msal-test-app.yml
       parameters:
         productFlavors: Dist
         signingConfigurations: Debug
         msalVersion: $(versionNumber)
         packageVariant: RC
-    - template: ./templates/build-adal-test-app.yml
+    - template: ../uiautomation/templates/build-adal-test-app.yml
       parameters:
         productFlavors: Dist
         signingConfigurations: Debug

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -554,14 +554,14 @@ stages:
       parameters:
         productFlavors: Dist
         signingConfigurations: Debug
-        msalVersion: $(versionNumber)
+        msalVersion: ${{ parameters.msalVersionRC }}
         packageVariant: RC
     - template: ./templates/build-adal-test-app.yml
       parameters:
         productFlavors: Dist
         signingConfigurations: Debug
-        commonVersion: $(versionNumber)
-        adalVersion: $(versionNumber)
+        adalVersion: ${{ parameters.adalVersionRC }}
+        commonVersion: ${{ parameters.commonVersionRC }}
         packageVariant: RC
 # Download First Party Apps
 - stage: 'firstpartyapps'

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -550,6 +550,19 @@ stages:
         brokerSource: LocalApk
         adalVersion: ${{ parameters.adalVersionRC }}
         commonVersion: ${{ parameters.commonVersionRC }}
+    - template: ./templates/build-msal-test-app.yml
+      parameters:
+        productFlavors: Dist
+        signingConfigurations: Debug
+        msalVersion: $(versionNumber)
+        packageVariant: RC
+    - template: ./templates/build-adal-test-app.yml
+      parameters:
+        productFlavors: Dist
+        signingConfigurations: Debug
+        commonVersion: $(versionNumber)
+        adalVersion: $(versionNumber)
+        packageVariant: RC
 # Download First Party Apps
 - stage: 'firstpartyapps'
   dependsOn:

--- a/azure-pipelines/ui-automation/templates/build-adal-test-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-adal-test-app.yml
@@ -66,8 +66,7 @@ jobs:
   - task: CmdLine@2
     displayName: print file structure
     inputs:
-      script: |
-      tree $(Agent.BuildDirectory)
+      script: tree $(Agent.BuildDirectory)
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble adalTestApp

--- a/azure-pipelines/ui-automation/templates/build-adal-test-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-adal-test-app.yml
@@ -79,3 +79,4 @@ jobs:
       targetPath: $(Agent.BuildDirectory)/android-complete/adal/userappwithbroker/build/outputs/apk/${{ lower(parameters.productFlavors) }}/${{ lower(parameters.signingConfigurations) }}
       artifactName: adalTestApp
       patterns: '**/*.apk'
+...

--- a/azure-pipelines/ui-automation/templates/build-adal-test-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-adal-test-app.yml
@@ -63,6 +63,11 @@ jobs:
     inputs:
       filename: echo
       arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(System.AccessToken)'
+  - task: CmdLine@2
+    displayName: print file structure
+    inputs:
+      script: |
+      tree $(Agent.BuildDirectory)
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble adalTestApp

--- a/azure-pipelines/ui-automation/templates/build-adal-test-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-adal-test-app.yml
@@ -1,0 +1,81 @@
+parameters:
+  - name: productFlavors
+    displayName: Product Flavor
+    type: string
+    default: Local
+    values:
+      - Local
+      - Dist
+  - name: signingConfigurations
+    displayName: Signing Configuration
+    type: string
+    default: Debug
+    values:
+      - Debug
+      - Release
+  - name: adalVersion
+    displayName: ADAL Version
+    type: string
+  - name: commonVersion
+    displayName: Common Version
+    type: string
+  - name: packageVariant
+    displayName: Package Variant
+    type: string
+    default: PROD
+    values:
+      - PROD
+      - RC
+
+jobs:
+- job: adal_test_app${{ parameters.packageVariant }}${{ parameters.productFlavors }}${{ parameters.signingConfigurations }}
+  displayName: Build ADAL Test App ${{ parameters.packageVariant }} ${{ parameters.productFlavors }} ${{ parameters.signingConfigurations }} APK
+  pool:
+    vmImage: 'windows-latest'
+  variables:
+  - group: AndroidAuthClientVariables
+  steps:
+  - checkout: self
+    clean: true
+    path: android-complete
+  - checkout: adal
+    clean: true
+    path: android-complete/adal
+  - ${{ if eq(parameters.productFlavors, 'Dist') }}:
+    - task: PowerShell@2
+      displayName: Generate Assemble Dist Task
+      inputs:
+        targetType: inline
+        script: |
+          $assembleTask = "assembleDist${{ parameters.signingConfigurations }}"
+          if (("${{ parameters.commonVersion }}" -ne "")) {
+              $assembleTask = $assembleTask + " -PdistCommonVersion=" + "${{ parameters.commonVersion }}"
+          }
+          if (("${{ parameters.adalVersion }}" -ne "")) {
+              $assembleTask = $assembleTask + " -PdistAdalVersion=" + "${{ parameters.adalVersion }}"
+          }
+          Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
+  - ${{ if eq(parameters.productFlavors, 'Local') }}:
+      - pwsh: echo "##vso[task.setvariable variable=AssembleTask;]assembleLocal${{ parameters.signingConfigurations }}"
+        displayName: Generate Assemble Local Task
+  - task: CmdLine@1
+    displayName: Set MVN AccessToken in Environment
+    inputs:
+      filename: echo
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(System.AccessToken)'
+  - task: Gradle@1
+    name: Gradle1
+    displayName: Assemble adalTestApp
+    inputs:
+      tasks: adalTestApp:clean adalTestApp:$(AssembleTask)
+      publishJUnitResults: false
+      jdkArchitecture: x86
+      sqAnalysisBreakBuildIfQualityGateFailed: false
+      gradleWrapperFile: $(Agent.BuildDirectory)/android-complete/gradlew
+      cwd: $(Agent.BuildDirectory)/android-complete
+  - task: PublishPipelineArtifact@1
+    displayName: Publish Adal Host APK
+    inputs:
+      targetPath: $(Agent.BuildDirectory)/android-complete/adal/userappwithbroker/build/outputs/apk/${{ lower(parameters.productFlavors) }}/${{ lower(parameters.signingConfigurations) }}
+      artifactName: adalTestApp
+      patterns: '**/*.apk'

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -59,7 +59,7 @@ jobs:
           jdkArchitecture: x86
           sqAnalysisBreakBuildIfQualityGateFailed: false
           gradleWrapperFile: $(Agent.BuildDirectory)
-          cwd: $(Agent.BuildDirectory)
+          cwd: $(Agent.BuildDirectory)/gradlew
       - task: CopyFiles@2
         displayName: 'Copy apks for later use in the pipeline'
         continueOnError: ${{ parameters.continueOnError }}

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -58,8 +58,8 @@ jobs:
           publishJUnitResults: false
           jdkArchitecture: x86
           sqAnalysisBreakBuildIfQualityGateFailed: false
-          gradleWrapperFile: $(Agent.WorkFolder)/1/gradlew
-          cwd: $(Agent.WorkFolder)/1
+          gradleWrapperFile: $(Agent.BuildDirectory)/gradlew
+      cwd: $(Agent.BuildDirectory)
       - task: CopyFiles@2
         displayName: 'Copy apks for later use in the pipeline'
         continueOnError: ${{ parameters.continueOnError }}

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -48,7 +48,7 @@ jobs:
       - task: CmdLine@2
         displayName: print file structure
         inputs:
-          script: tree $(Agent.BuildDirectory) /f
+          script: tree $(Agent.BuildDirectory)/s /f
       - task: Gradle@1
         name: Gradle1
         displayName: Assemble Azure Sample
@@ -58,8 +58,8 @@ jobs:
           publishJUnitResults: false
           jdkArchitecture: x86
           sqAnalysisBreakBuildIfQualityGateFailed: false
-          gradleWrapperFile: $(Agent.BuildDirectory)/gradlew
-          cwd: $(Agent.BuildDirectory)
+          gradleWrapperFile: $(Agent.BuildDirectory)/s/gradlew
+          cwd: $(Agent.BuildDirectory)/s
       - task: CopyFiles@2
         displayName: 'Copy apks for later use in the pipeline'
         continueOnError: ${{ parameters.continueOnError }}

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -59,7 +59,7 @@ jobs:
           jdkArchitecture: x86
           sqAnalysisBreakBuildIfQualityGateFailed: false
           gradleWrapperFile: $(Agent.BuildDirectory)/gradlew
-      cwd: $(Agent.BuildDirectory)
+          cwd: $(Agent.BuildDirectory)
       - task: CopyFiles@2
         displayName: 'Copy apks for later use in the pipeline'
         continueOnError: ${{ parameters.continueOnError }}

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -71,7 +71,7 @@ jobs:
         displayName: Publish Azure Sample (Standalone) APK
         continueOnError: ${{ parameters.continueOnError }}
         inputs:
-          targetPath: $(Agent.BuildDirectory)/ms-identity-android-java/azuresample/app/build/outputs/apk/standalone/external/${{ lower(parameters.signingConfigurations) }}
+          targetPath: $(Agent.BuildDirectory)/ms-identity-android-java/azuresample/app/build/outputs/apk/$(packageVariant)/${{ lower(parameters.signingConfigurations) }}
           artifactName: AzureSample-standalone-${{upper(parameters.packageVariant)}}
           patterns: '**/*.apk'
 ...

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -45,12 +45,16 @@ jobs:
         inputs:
           filename: echo
           arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(System.AccessToken)'
+      - task: CmdLine@2
+        displayName: print file structure
+        inputs:
+          script: tree $(Agent.WorkFolder)\1 /f
       - task: Gradle@1
         name: Gradle1
         displayName: Assemble Azure Sample
         continueOnError: ${{ parameters.continueOnError }}
         inputs:
-          tasks: AzureSample:clean AzureSample:$(AssembleTask)
+          tasks: app:clean app:$(AssembleTask)
           publishJUnitResults: false
           jdkArchitecture: x86
           sqAnalysisBreakBuildIfQualityGateFailed: false

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -44,7 +44,7 @@ jobs:
         displayName: Set MVN AccessToken in Environment
         inputs:
           filename: echo
-          arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(System.AccessToken)'
+          arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADAL_ACCESSTOKEN]$(System.AccessToken)'
       - task: CmdLine@2
         displayName: print file structure
         inputs:

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -72,6 +72,6 @@ jobs:
         continueOnError: ${{ parameters.continueOnError }}
         inputs:
           targetPath: $(Agent.BuildDirectory)/s/app/build/outputs/apk/external/${{ lower(parameters.signingConfigurations) }}
-          artifactName: AzureSample-${{upper(parameters.packageVariant)}}
+          artifactName: AzureSample-Standalone-${{upper(parameters.packageVariant)}}
           patterns: '**/*.apk'
 ...

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -48,7 +48,9 @@ jobs:
       - task: CmdLine@2
         displayName: print file structure
         inputs:
-          script: tree $(Agent.WorkFolder)\1 /f
+          script: |
+          tree $(Agent.WorkFolder)\1 /f
+          tree $(Agent.BuildDirectory)
       - task: Gradle@1
         name: Gradle1
         displayName: Assemble Azure Sample

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -71,7 +71,7 @@ jobs:
         displayName: Publish Azure Sample (Standalone) APK
         continueOnError: ${{ parameters.continueOnError }}
         inputs:
-          targetPath: $(Agent.BuildDirectory)/ms-identity-android-java/azuresample/app/build/outputs/apk/${{ parameters.packageVariant }}/${{ lower(parameters.signingConfigurations) }}
+          targetPath: $(Agent.BuildDirectory)/ms-identity-android-java/azuresample/app/build/outputs/apk/external/${{ lower(parameters.signingConfigurations) }}
           artifactName: AzureSample-${{upper(parameters.packageVariant)}}
           patterns: '**/*.apk'
 ...

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -58,8 +58,8 @@ jobs:
           publishJUnitResults: false
           jdkArchitecture: x86
           sqAnalysisBreakBuildIfQualityGateFailed: false
-          gradleWrapperFile: $(Agent.BuildDirectory)/ms-identity-android-java/gradlew
-          cwd: $(Agent.BuildDirectory)/ms-identity-android-java
+          gradleWrapperFile: $(Agent.BuildDirectory)
+          cwd: $(Agent.BuildDirectory)
       - task: CopyFiles@2
         displayName: 'Copy apks for later use in the pipeline'
         continueOnError: ${{ parameters.continueOnError }}

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -16,6 +16,9 @@ parameters:
     values:
       - PROD
       - RC
+  - name: continueOnError
+    type: boolean
+    default: False
 
 jobs:
   - job: azure_samples_standalone${{ parameters.packageVariant }}External${{ parameters.signingConfigurations }}
@@ -46,6 +49,7 @@ jobs:
       - task: Gradle@1
         name: Gradle1
         displayName: Assemble Azure Sample
+        continueOnError: ${{ parameters.continueOnError }}
         inputs:
           tasks: AzureSample:clean AzureSample:$(AssembleTask)
           publishJUnitResults: false
@@ -55,12 +59,14 @@ jobs:
           cwd: $(Agent.BuildDirectory)/ms-identity-android-java
       - task: CopyFiles@2
         displayName: 'Copy apks for later use in the pipeline'
+        continueOnError: ${{ parameters.continueOnError }}
         inputs:
           flattenFolders: true
           contents: '$(Build.SourcesDirectory)/azuresample/build/outputs/apk/**/*.apk'
           targetFolder: $(Build.ArtifactStagingDirectory)/azuresample/$(packageVariant)
       - task: PublishPipelineArtifact@1
         displayName: Publish Azure Sample (Standalone) APK
+        continueOnError: ${{ parameters.continueOnError }}
         inputs:
           targetPath: $(Agent.BuildDirectory)/ms-identity-android-java/azuresample/app/build/outputs/apk/standalone/external/${{ lower(parameters.signingConfigurations) }}
           artifactName: AzureSample-standalone-${{upper(parameters.packageVariant)}}

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -51,8 +51,8 @@ jobs:
           publishJUnitResults: false
           jdkArchitecture: x86
           sqAnalysisBreakBuildIfQualityGateFailed: false
-          gradleWrapperFile: $(Agent.BuildDirectory)/android-complete/gradlew
-          cwd: $(Agent.BuildDirectory)/android-complete
+          gradleWrapperFile: $(Agent.BuildDirectory)/ms-identity-android-java/gradlew
+          cwd: $(Agent.BuildDirectory)/ms-identity-android-java
       - task: CopyFiles@2
         displayName: 'Copy apks for later use in the pipeline'
         inputs:
@@ -62,7 +62,7 @@ jobs:
       - task: PublishPipelineArtifact@1
         displayName: Publish Azure Sample (Standalone) APK
         inputs:
-          targetPath: $(Agent.BuildDirectory)/android-complete/azuresample/app/build/outputs/apk/standalone/external/${{ lower(parameters.signingConfigurations) }}
+          targetPath: $(Agent.BuildDirectory)/ms-identity-android-java/azuresample/app/build/outputs/apk/standalone/external/${{ lower(parameters.signingConfigurations) }}
           artifactName: AzureSample-standalone-${{upper(parameters.packageVariant)}}
           patterns: '**/*.apk'
 ...

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -48,9 +48,7 @@ jobs:
       - task: CmdLine@2
         displayName: print file structure
         inputs:
-          script: |
-          tree $(Agent.WorkFolder)\1 /f
-          tree $(Agent.BuildDirectory)
+          script: tree $(Agent.BuildDirectory) /f
       - task: Gradle@1
         name: Gradle1
         displayName: Assemble Azure Sample

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -58,8 +58,8 @@ jobs:
           publishJUnitResults: false
           jdkArchitecture: x86
           sqAnalysisBreakBuildIfQualityGateFailed: false
-          gradleWrapperFile: $(Agent.WorkFolder)/gradlew
-          cwd: $(Agent.WorkFolder)
+          gradleWrapperFile: $(Agent.WorkFolder)/1/gradlew
+          cwd: $(Agent.WorkFolder)/1
       - task: CopyFiles@2
         displayName: 'Copy apks for later use in the pipeline'
         continueOnError: ${{ parameters.continueOnError }}

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -30,7 +30,6 @@ jobs:
     steps:
       - checkout: azuresample
         clean: true
-        path: android-complete/azuresample
       - task: PowerShell@2
         displayName: Generate Assemble External Task
         inputs:

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -72,6 +72,6 @@ jobs:
         continueOnError: ${{ parameters.continueOnError }}
         inputs:
           targetPath: $(Agent.BuildDirectory)/ms-identity-android-java/azuresample/app/build/outputs/apk/${{ parameters.packageVariant }}/${{ lower(parameters.signingConfigurations) }}
-          artifactName: AzureSample-standalone-${{upper(parameters.packageVariant)}}
+          artifactName: AzureSample-${{upper(parameters.packageVariant)}}
           patterns: '**/*.apk'
 ...

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -1,0 +1,68 @@
+parameters:
+  - name: signingConfigurations
+    displayName: Signing Configuration
+    type: string
+    default: Debug
+    values:
+      - Debug
+      - Release
+  - name: msalVersion
+    displayName: MSAL Version
+    type: string
+  - name: packageVariant
+    displayName: Package Variant
+    type: string
+    default: PROD
+    values:
+      - PROD
+      - RC
+
+jobs:
+  - job: azure_samples_standalone${{ parameters.packageVariant }}External${{ parameters.signingConfigurations }}
+    displayName: Build Azure Samples (Azure Sample Repo) ${{ parameters.packageVariant }} External ${{ parameters.signingConfigurations }} APK
+    pool:
+      vmImage: 'windows-latest'
+    variables:
+      - group: AndroidAuthClientVariables
+    steps:
+      - checkout: azuresample
+        clean: true
+        path: android-complete/azuresample
+      - task: PowerShell@2
+        displayName: Generate Assemble External Task
+        inputs:
+          targetType: inline
+          script: |
+            $assembleTask = "assembleExternal${{ parameters.signingConfigurations }}"
+            if (("${{ parameters.msalVersion }}" -ne "")) {
+                $assembleTask = $assembleTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
+            }
+            Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
+      - task: CmdLine@1
+        displayName: Set MVN AccessToken in Environment
+        inputs:
+          filename: echo
+          arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(System.AccessToken)'
+      - task: Gradle@1
+        name: Gradle1
+        displayName: Assemble Azure Sample
+        inputs:
+          tasks: AzureSample:clean AzureSample:$(AssembleTask)
+          publishJUnitResults: false
+          jdkArchitecture: x86
+          sqAnalysisBreakBuildIfQualityGateFailed: false
+          gradleWrapperFile: $(Agent.BuildDirectory)/android-complete/gradlew
+          cwd: $(Agent.BuildDirectory)/android-complete
+      - task: CopyFiles@2
+        displayName: 'Copy apks for later use in the pipeline'
+        inputs:
+          flattenFolders: true
+          contents: '$(Build.SourcesDirectory)/azuresample/build/outputs/apk/**/*.apk'
+          targetFolder: $(Build.ArtifactStagingDirectory)/azuresample/$(packageVariant)
+      - task: PublishPipelineArtifact@1
+        displayName: Publish Azure Sample (Standalone) APK
+        inputs:
+          targetPath: $(Agent.BuildDirectory)/android-complete/azuresample/app/build/outputs/apk/standalone/external/${{ lower(parameters.signingConfigurations) }}
+          artifactName: AzureSample-standalone-${{upper(parameters.packageVariant)}}
+          patterns: '**/*.apk'
+...

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -58,8 +58,8 @@ jobs:
           publishJUnitResults: false
           jdkArchitecture: x86
           sqAnalysisBreakBuildIfQualityGateFailed: false
-          gradleWrapperFile: $(Agent.BuildDirectory)
-          cwd: $(Agent.BuildDirectory)/gradlew
+          gradleWrapperFile: $(Agent.WorkFolder)/gradlew
+          cwd: $(Agent.WorkFolder)
       - task: CopyFiles@2
         displayName: 'Copy apks for later use in the pipeline'
         continueOnError: ${{ parameters.continueOnError }}

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -66,12 +66,12 @@ jobs:
         inputs:
           flattenFolders: true
           contents: '$(Build.SourcesDirectory)/azuresample/build/outputs/apk/**/*.apk'
-          targetFolder: $(Build.ArtifactStagingDirectory)/azuresample/$(packageVariant)
+          targetFolder: $(Build.ArtifactStagingDirectory)/azuresample/${{ parameters.packageVariant }}
       - task: PublishPipelineArtifact@1
         displayName: Publish Azure Sample (Standalone) APK
         continueOnError: ${{ parameters.continueOnError }}
         inputs:
-          targetPath: $(Agent.BuildDirectory)/ms-identity-android-java/azuresample/app/build/outputs/apk/$(packageVariant)/${{ lower(parameters.signingConfigurations) }}
+          targetPath: $(Agent.BuildDirectory)/ms-identity-android-java/azuresample/app/build/outputs/apk/${{ parameters.packageVariant }}/${{ lower(parameters.signingConfigurations) }}
           artifactName: AzureSample-standalone-${{upper(parameters.packageVariant)}}
           patterns: '**/*.apk'
 ...

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app-standalone.yml
@@ -71,7 +71,7 @@ jobs:
         displayName: Publish Azure Sample (Standalone) APK
         continueOnError: ${{ parameters.continueOnError }}
         inputs:
-          targetPath: $(Agent.BuildDirectory)/ms-identity-android-java/azuresample/app/build/outputs/apk/external/${{ lower(parameters.signingConfigurations) }}
+          targetPath: $(Agent.BuildDirectory)/s/app/build/outputs/apk/external/${{ lower(parameters.signingConfigurations) }}
           artifactName: AzureSample-${{upper(parameters.packageVariant)}}
           patterns: '**/*.apk'
 ...

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app.yml
@@ -78,7 +78,7 @@ jobs:
     inputs:
       flattenFolders: true
       contents: '$(Build.SourcesDirectory)/azuresample/build/outputs/apk/**/*.apk'
-      targetFolder: $(Build.ArtifactStagingDirectory)/azuresample/$(packageVariant)
+      targetFolder: $(Build.ArtifactStagingDirectory)/azuresample/${{ parameters.packageVariant }}
   - task: PublishPipelineArtifact@1
     displayName: Publish Azure Sample APK
     inputs:

--- a/azure-pipelines/ui-automation/templates/build-azure-sample-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-azure-sample-app.yml
@@ -80,7 +80,7 @@ jobs:
       contents: '$(Build.SourcesDirectory)/azuresample/build/outputs/apk/**/*.apk'
       targetFolder: $(Build.ArtifactStagingDirectory)/azuresample/$(packageVariant)
   - task: PublishPipelineArtifact@1
-    displayName: Publish Broker Host APK
+    displayName: Publish Azure Sample APK
     inputs:
       targetPath: $(Agent.BuildDirectory)/android-complete/azuresample/app/build/outputs/apk/${{ lower(parameters.productFlavors) }}/${{ lower(parameters.signingConfigurations) }}
       artifactName: AzureSample-${{upper(parameters.packageVariant)}}

--- a/azure-pipelines/ui-automation/templates/build-msal-test-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-test-app.yml
@@ -1,0 +1,75 @@
+parameters:
+  - name: productFlavors
+    displayName: Product Flavor
+    type: string
+    default: Local
+    values:
+      - Local
+      - Dist
+  - name: signingConfigurations
+    displayName: Signing Configuration
+    type: string
+    default: Debug
+    values:
+      - Debug
+      - Release
+  - name: msalVersion
+    displayName: MSAL Version
+    type: string
+  - name: packageVariant
+    displayName: Package Variant
+    type: string
+    default: PROD
+    values:
+      - PROD
+      - RC
+
+jobs:
+- job: msal_test_app${{ parameters.packageVariant }}${{ parameters.productFlavors }}${{ parameters.signingConfigurations }}
+  displayName: Build MSAL Test App ${{ parameters.packageVariant }} ${{ parameters.productFlavors }} ${{ parameters.signingConfigurations }} APK
+  pool:
+    vmImage: 'windows-latest'
+  variables:
+    - group: AndroidAuthClientVariables
+  steps:
+  - checkout: self
+    clean: true
+    path: android-complete
+  - checkout: msal
+    clean: true
+    path: android-complete/adal
+  - ${{ if eq(parameters.productFlavors, 'Dist') }}:
+    - task: PowerShell@2
+      displayName: Generate Assemble Dist Task
+      inputs:
+        targetType: inline
+        script: |
+          $assembleTask = "assembleDist${{ parameters.signingConfigurations }}"
+          if (("${{ parameters.msalVersion }}" -ne "")) {
+              $assembleTask = $assembleTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
+          }
+          Write-Host "##vso[task.setvariable variable=AssembleTask;]$assembleTask"
+  - ${{ if eq(parameters.productFlavors, 'Local') }}:
+    - pwsh: echo "##vso[task.setvariable variable=AssembleTask;]assembleLocal${{ parameters.signingConfigurations }}"
+      displayName: Generate Assemble Local Task
+  - task: CmdLine@1
+    displayName: Set MVN AccessToken in Environment
+    inputs:
+      filename: echo
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(System.AccessToken)'
+  - task: Gradle@1
+    name: Gradle1
+    displayName: Assemble msalTestApp
+    inputs:
+      tasks: msalTestApp:clean msalTestApp:$(AssembleTask)
+      publishJUnitResults: false
+      jdkArchitecture: x86
+      sqAnalysisBreakBuildIfQualityGateFailed: false
+      gradleWrapperFile: $(Agent.BuildDirectory)/android-complete/gradlew
+      cwd: $(Agent.BuildDirectory)/android-complete
+  - task: PublishPipelineArtifact@1
+    displayName: Publish MSAL Test App
+    inputs:
+      targetPath: $(Agent.BuildDirectory)/android-complete/msal/testapps/testapp/build/outputs/apk/${{ lower(parameters.productFlavors) }}/${{ lower(parameters.signingConfigurations) }}
+      artifactName: msalTestApp
+      patterns: '**/*.apk''

--- a/azure-pipelines/ui-automation/templates/build-msal-test-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-test-app.yml
@@ -72,4 +72,5 @@ jobs:
     inputs:
       targetPath: $(Agent.BuildDirectory)/android-complete/msal/testapps/testapp/build/outputs/apk/${{ lower(parameters.productFlavors) }}/${{ lower(parameters.signingConfigurations) }}
       artifactName: msalTestApp
-      patterns: '**/*.apk''
+      patterns: '**/*.apk'
+...

--- a/azure-pipelines/ui-automation/templates/build-msal-test-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-test-app.yml
@@ -38,6 +38,12 @@ jobs:
   - checkout: msal
     clean: true
     path: android-complete/msal
+  - checkout: broker
+    clean: true
+    path: android-complete/broker
+  - checkout: common
+    clean: true
+    path: android-complete/common
   - ${{ if eq(parameters.productFlavors, 'Dist') }}:
     - task: PowerShell@2
       displayName: Generate Assemble Dist Task

--- a/azure-pipelines/ui-automation/templates/build-msal-test-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-test-app.yml
@@ -37,7 +37,7 @@ jobs:
     path: android-complete
   - checkout: msal
     clean: true
-    path: android-complete/adal
+    path: android-complete/msal
   - ${{ if eq(parameters.productFlavors, 'Dist') }}:
     - task: PowerShell@2
       displayName: Generate Assemble Dist Task


### PR DESCRIPTION
This allows us to validate that our apps are building properly as part of the daily pipeline run. This includes:

Azure Sample
Azure Sample (Standalone)
BrokerHost
MSAL Test App
Adal Test App

Also included MSAL Test App and Adal Test App in the release pipeline, this will remove 2 steps from the release process (previously, engineer would have to run 2 separate pipelines for the msal and adal test apps respectively).

Also added some boolean parameters to skip running unit and instrumented tests in the daily pipeline.

https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1145618&view=results
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1144121&view=results