### PR TITLE
Download broker host with broker selection disabled

### DIFF
--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -301,6 +301,7 @@ stages:
                       /sdcard/OldOneAuthTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(oneAuthTestApp),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
+                      /sdcard/BrokerHostWithoutBrokerSelection.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhostWithoutBrokerSelectionEnabled_apk),\
                       /sdcard/OneAuthTestApp.apk=$(Pipeline.WorkSpace)/oneauthtestapp/$(oneAuthTestApp),\
                       /sdcard/Edge.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk),\
                       /sdcard/MsalTestApp.apk=$(Pipeline.WorkSpace)/msalE2ETestApp/$(msalE2ETestApp)"
@@ -334,6 +335,7 @@ stages:
                       /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldltwApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/OldBrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhost_apk),\
+                      /sdcard/BrokerHostWithoutBrokerSelection.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhostWithoutBrokerSelectionEnabled_apk),\
                       /sdcard/OldMsalTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(msalE2ETestApp),\
                       /sdcard/OldOneAuthTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(oneAuthTestApp),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
@@ -373,6 +375,7 @@ stages:
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/OldMsalTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(msalE2ETestApp),\
                       /sdcard/OldOneAuthTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(oneAuthTestApp),\
+                      /sdcard/BrokerHostWithoutBrokerSelection.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhostWithoutBrokerSelectionEnabled_apk),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
                       /sdcard/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\
@@ -406,6 +409,7 @@ stages:
                       /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/$(LTWApk),\
                       /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldltwApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
+                      /sdcard/BrokerHostWithoutBrokerSelection.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhostWithoutBrokerSelectionEnabled_apk),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
                       /sdcard/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -102,6 +102,10 @@ parameters:
   displayName: Old Broker host Version
   type: string
   default: '0.0.1'
+- name: brokerHostWithoutBrokerSelectionLogicVersion
+  displayName: brokerHost without broker selection logic version
+  type: string
+  default: '0.0.3'
 - name: LTWVersion
   displayName: Link to Windows Version
   type: string
@@ -256,6 +260,7 @@ stages:
         oldCompanyPortalVersion: ${{ parameters.oldCompanyPortalVersion }}
         brokerHostPipelineId: '$(brokerHostPipelineId)'
         oldBrokerHostVersion: ${{ parameters.oldBrokerHostVersion }}
+        brokerHostWithoutBrokerSelectionLogicVersion: ${{ parameters.brokerHostWithoutBrokerSelectionLogicVersion }}
         LTWVersion: ${{ parameters.LTWVersion }}
         oldLTWVersion: ${{ parameters.oldLTWVersion }}
 # Download Old Test Apps

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -105,7 +105,7 @@ parameters:
 - name: brokerHostWithoutBrokerSelectionLogicVersion
   displayName: brokerHost without broker selection logic version
   type: string
-  default: '0.0.3'
+  default: '0.0.4'
 - name: LTWVersion
   displayName: Link to Windows Version
   type: string

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -160,6 +160,7 @@ jobs:
         feedDownloadExternal: '${{ parameters.msazureFeedName }}'
         packageDownloadExternal: 'broker-host'
         versionDownloadExternal: '${{ parameters.oldBrokerHostVersion }}'
+    - script: mv ./broker-host.apk ./BrokerHostWithoutBrokerSelection.apk
     - publish: $(Build.ArtifactStagingDirectory)/brokers
       displayName: 'Publish Authenticator/Company Portal Broker apks for later use'
       artifact: brokerapks

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -29,7 +29,7 @@ parameters:
   - name: brokerHostWithoutBrokerSelectionLogicVersion
     displayName: brokerHost without broker selection logic version
     type: string
-    default: '0.0.3'
+    default: '0.0.4'
   - name: internalFeedName
     type: string
     default: 'AndroidAdal'

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -160,7 +160,6 @@ jobs:
         feedDownloadExternal: '${{ parameters.msazureFeedName }}'
         packageDownloadExternal: 'broker-host'
         versionDownloadExternal: '${{ parameters.oldBrokerHostVersion }}'
-    - script: mv ./broker-host.apk ./BrokerHostWithoutBrokerSelection.apk
     - publish: $(Build.ArtifactStagingDirectory)/brokers
       displayName: 'Publish Authenticator/Company Portal Broker apks for later use'
       artifact: brokerapks

--- a/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
+++ b/azure-pipelines/ui-automation/templates/download-brokers-and-azure-sample.yml
@@ -26,6 +26,10 @@ parameters:
   - name: oldBrokerHostVersion
     displayName: Old Broker host Version
     type: string
+  - name: brokerHostWithoutBrokerSelectionLogicVersion
+    displayName: brokerHost without broker selection logic version
+    type: string
+    default: '0.0.3'
   - name: internalFeedName
     type: string
     default: 'AndroidAdal'
@@ -138,6 +142,16 @@ jobs:
         targetPath: '$(Build.ArtifactStagingDirectory)/brokers'
     - task: UniversalPackages@0
       displayName: 'Download old brokerHost version from feed'
+      inputs:
+        command: 'download'
+        downloadDirectory: '$(Build.ArtifactStagingDirectory)/brokers/oldAPKs'
+        feedsToUse: 'external'
+        externalFeedCredentials: '${{ parameters.msazureServiceConnection }}'
+        feedDownloadExternal: '${{ parameters.msazureFeedName }}'
+        packageDownloadExternal: 'broker-host'
+        versionDownloadExternal: '${{ parameters.brokerHostWithoutBrokerSelectionLogicVersion }}'
+    - task: UniversalPackages@0
+      displayName: 'Download brokerHost without broker selection logic from feed'
       inputs:
         command: 'download'
         downloadDirectory: '$(Build.ArtifactStagingDirectory)/brokers/oldAPKs'


### PR DESCRIPTION
Added a task to download broker host app that is uploaded to Android-broker feed. The broker host app does not have broker selection logic enabled but has all the recent features like MWPJ and LTW code with flag as off.