### PR TITLE
Fixing publish lockfile task

### DIFF
--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -82,13 +82,13 @@ jobs:
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)/${{ parameters.project }}'
       Contents: '**/*.lockfile'
-      TargetFolder: '$(Build.SourcesDirectory)/${{ parameters.project }}/LockfileFolder'
+      TargetFolder: '$(Build.SourcesDirectory)/${{ parameters.project }}/dependencies'
       OverWrite: true
       flattenFolders: false
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Artifact: dependencies lockfile'
     inputs:
-      targetPath: $(Build.SourcesDirectory)/${{ parameters.project }}/LockfileFolder
+      targetPath: $(Build.SourcesDirectory)/${{ parameters.project }}/dependencies
       ArtifactName: ${{ parameters.project }}_dependencies
     inputs:
       BuildDropPath: $(Build.SourcesDirectory)/${{ parameters.project }}/build/

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -83,7 +83,7 @@ jobs:
   - task: CopyFiles@2
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)/${{ parameters.project }}' # Source folder containing the files
-      Contents: '**/.lockfile'     # Replace with your file format (e.g., **/*.txt)
+      Contents: '**/*.lockfile'     # Replace with your file format (e.g., **/*.txt)
       TargetFolder: '$(Build.SourcesDirectory)/${{ parameters.project }}/LockfileFolder'
       OverWrite: true                          # Overwrite files if they already exist in the target folder
       flattenFolders: false                    # Maintain folder structure

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -80,10 +80,17 @@ jobs:
     displayName: 'Generate SBOM manifest file'
     inputs:
       BuildDropPath: $(Build.SourcesDirectory)/${{ parameters.project }}/build/
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)/${{ parameters.project }}' # Source folder containing the files
+      Contents: '**/.lockfile'     # Replace with your file format (e.g., **/*.txt)
+      TargetFolder: '$(Build.SourcesDirectory)/${{ parameters.project }}/LockfileFolder'
+      OverWrite: true                          # Overwrite files if they already exist in the target folder
+      flattenFolders: false                    # Maintain folder structure
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Artifact: dependencies lockfile'
     inputs:
-      targetPath: $(Build.SourcesDirectory)/${{ parameters.project }}/
+      targetPath: $(Build.SourcesDirectory)/${{ parameters.project }}/LockfileFolder
       ArtifactName: ${{ parameters.project }}_dependencies
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Artifact: ${{ parameters.project }} Release'

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -78,20 +78,20 @@ jobs:
       sourceScanPath: $(Build.SourcesDirectory)/${{ parameters.project }}/
   - task: ManifestGeneratorTask@0
     displayName: 'Generate SBOM manifest file'
-    inputs:
-      BuildDropPath: $(Build.SourcesDirectory)/${{ parameters.project }}/build/
   - task: CopyFiles@2
     inputs:
-      SourceFolder: '$(Build.SourcesDirectory)/${{ parameters.project }}' # Source folder containing the files
-      Contents: '**/*.lockfile'     # Replace with your file format (e.g., **/*.txt)
+      SourceFolder: '$(Build.SourcesDirectory)/${{ parameters.project }}'
+      Contents: '**/*.lockfile'
       TargetFolder: '$(Build.SourcesDirectory)/${{ parameters.project }}/LockfileFolder'
-      OverWrite: true                          # Overwrite files if they already exist in the target folder
-      flattenFolders: false                    # Maintain folder structure
+      OverWrite: true
+      flattenFolders: false
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Artifact: dependencies lockfile'
     inputs:
       targetPath: $(Build.SourcesDirectory)/${{ parameters.project }}/LockfileFolder
       ArtifactName: ${{ parameters.project }}_dependencies
+    inputs:
+      BuildDropPath: $(Build.SourcesDirectory)/${{ parameters.project }}/build/
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Artifact: ${{ parameters.project }} Release'
     inputs:

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -79,7 +79,7 @@ jobs:
   - task: ManifestGeneratorTask@0
     displayName: 'Generate SBOM manifest file'
     inputs:
-    BuildDropPath: $(Build.SourcesDirectory)/${{ parameters.project }}/build/
+      BuildDropPath: $(Build.SourcesDirectory)/${{ parameters.project }}/build/
   - task: CopyFiles@2
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)/${{ parameters.project }}'

--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -78,6 +78,8 @@ jobs:
       sourceScanPath: $(Build.SourcesDirectory)/${{ parameters.project }}/
   - task: ManifestGeneratorTask@0
     displayName: 'Generate SBOM manifest file'
+    inputs:
+    BuildDropPath: $(Build.SourcesDirectory)/${{ parameters.project }}/build/
   - task: CopyFiles@2
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)/${{ parameters.project }}'
@@ -90,8 +92,6 @@ jobs:
     inputs:
       targetPath: $(Build.SourcesDirectory)/${{ parameters.project }}/dependencies
       ArtifactName: ${{ parameters.project }}_dependencies
-    inputs:
-      BuildDropPath: $(Build.SourcesDirectory)/${{ parameters.project }}/build/
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Artifact: ${{ parameters.project }} Release'
     inputs:


### PR DESCRIPTION
Issue  : Publish lockfile task to pipeline artifacts was publishing all the artifacts in the project's root folder.  Only gradle.lockfile should be published to project_depenendencies folder.

FIx : Filtering for .lockfile and publishing artifacts only with .lockfile

Pipeline run : https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1161099&view=results