### PR TITLE
Updated the default version of old company portal version in the pipeline

### DIFF
--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -99,7 +99,7 @@ parameters:
 - name: oldCompanyPortalVersion
   displayName: Old Company Portal Version
   type: string
-  default: '5.0.5729'
+  default: '5.0.604010354'
 - name: oldBrokerHostVersion
   displayName: Old Broker host Version
   type: string


### PR DESCRIPTION
Updated the default version of old company portal version in the pipeline. This new version of CP has PRTV3 enabled but has broker selection logic disabled.