### PR TITLE
Change agent in RunUnitTest job

### DIFF
--- a/azure-pipelines/continuous-delivery/assemble&publish.yml
+++ b/azure-pipelines/continuous-delivery/assemble&publish.yml
@@ -104,7 +104,10 @@ jobs:
   timeoutInMinutes: 120
   continueOnError: true
   pool:
-    vmImage: ubuntu-latest
+    ${{ if eq(parameters.agentImage, 'none') }}:
+      vmImage: ubuntu-latest
+    ${{ else }}:
+      name: ${{ parameters.agentImage }}
     variables:
       - group: AndroidAuthClientVariables
   steps:


### PR DESCRIPTION
WHY?


running test with ubuntu agents usually ends with OOM exceptions.
this change allows to use custom agents.