### PR TITLE
Update Old OneAuthtestApp version

### DIFF
--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -127,7 +127,7 @@ parameters:
 - name: oldOneAuthTestAppVersion
   displayName: Old OneAuth Test App Version
   type: string
-  default: '0.0.2'
+  default: '0.0.3'
 - name: preInstallLtw
   displayName: Preinstall Link to Windows
   type: boolean


### PR DESCRIPTION
Update old oneauthtestapp version to 0.0.3

What is the difference between 0.0.2 and 0.0.3?
- The package name of latest oneauthtestapp has changed. We have started using the new name in our automation tests and noticed that tests with old oneauth test app (test app with broker discovery disabled) are failing. I have generated a new test app with broker discovery disabled and uploaded it to the feed with version number as 0.0.3