### PR TITLE
Add native auth dependency + dependency versions

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -22,6 +22,7 @@
 		git clone -b dev https://github.com/AzureAD/ad-accounts-for-android.git broker; \
 		git clone -b working https://msazure.visualstudio.com/DefaultCollection/One/_git/AD-MFA-phonefactor-phoneApp-android authenticator; \
         git clone -b master https://github.com/Azure-Samples/ms-identity-android-java.git azuresample; \
+        git clone -b main git@github.com:Azure-Samples/ms-identity-ciam-native-auth-android-sample.git nativeauthsample; \
         git clone -b dev https://office.visualstudio.com/DefaultCollection/OneAuth/_git/OneAuth oneauth; \
         git clone -b develop https://github.com/AzureAD/microsoft-authentication-library-for-cpp.git msalcpp; \
         git clone -b master https://onedrive.visualstudio.com/DefaultCollection/SkyDrive/_git/AndroidTokenShare tsl; \
@@ -37,6 +38,7 @@
 		git clone -b dev https://github.com/AzureAD/microsoft-authentication-library-common-for-android.git common; \
 		git clone -b dev https://github.com/AzureAD/azure-activedirectory-library-for-android.git adal; \
         git clone -b master https://github.com/Azure-Samples/ms-identity-android-java.git azuresample; \
+        git clone -b main git@github.com:Azure-Samples/ms-identity-ciam-native-auth-android-sample.git nativeauthsample; \
 		cd msal; git submodule init; git submodule update; cd ..; \
 		cd adal; git submodule init; git submodule update; cd ..; \
 		workDir=$(pwd); \

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -69,6 +69,12 @@ ext {
     yubikitPivVersion = "2.3.0"
     powerliftAndroidVersion="1.0.3"
 
+    // Native auth additions
+    kotlinXCoroutinesVersion = "1.3.9"
+    kotlinXCoroutinesTestVersion = "1.6.4"
+    coreKtxVersion = "1.6.0"
+    mockitoKotlinVersion = '4.1.0'
+
     // microsoft-diagnostics-uploader app versions
     powerliftVersion = "0.14.7"
     cliktVersion = "3.4.2"

--- a/settings.gradle
+++ b/settings.gradle
@@ -122,6 +122,9 @@ project(':mockltw').projectDir = new File('broker/mockbrokers/mockltw')
 include(":mockbrokerapplib")
 project(':mockbrokerapplib').projectDir = new File('broker/mockbrokers/mockbrokerapplib')
 
+include(":NativeAuthSample")
+project(':NativeAuthSample').projectDir = new File('nativeauthsample/app')
+
 //include(":tsl")
 //project(':tsl').projectDir = new File('tsl/tokenshare')
 


### PR DESCRIPTION
- Add native auth sample app to `droidSetup` script
- Add native auth app to project settings
- Add native auth specific dependency versions to `versions.gradle`

note: native auth sample app is currently private. This means Github credentials are needed to download contents as part of `droidSetup`. Github doesn't support username + password, so this script uses SSH (which requires an SSH key). In February native auth will go to public preview and the respective sample app repo will become public. This `droidSetup` script can be updated then to pull from the HTTP source.