### PR TITLE
Fix step where oneauth test app is pulled from OneAuth pipeline

### DIFF
--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -212,36 +212,36 @@ stages:
           displayName: 'Publish Msal Test apk for later use'
           artifact: msalE2ETestApp
 # TestAppApk - OneAuthTestApp Queue pipeline
-#- stage: 'oneAuthTestApp'
-#  displayName: Build OneAuth Test App Apk
-#  dependsOn: []   # this removes the implicit dependency on previous stage and causes this to run in parallel
-#  jobs:
-#    - job: queue_build_OneAuthTestApp
-#      displayName: Generate OneAuth Test App Apk
-#      timeoutInMinutes: 120
-#      steps:
-#        - checkout: self
-#          persistCredentials: True
-#        - task: PowerShell@2
-#          displayName: Queue and wait for OneAuth Test App Apk generation pipeline
-#          name: buildApk
-#          continueOnError: true
-#          inputs:
-#            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-#            arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -Branch "android/common-ingestion" -TemplateParams "{''androidCommonVersion'': ''$(dailyVersion)''}"'
-#            workingDirectory: '$(Build.SourcesDirectory)'
-#          env:
-#            SYSTEM_ACCESSTOKEN: $(OfficePAT)
-#        - task: DownloadExternalBuildArtifacts@15
-#          displayName: 'Download OneAuth test app'
-#          inputs:
-#            connection: '$(oneAuthServiceConnection)'
-#            project: '$(oneAuthProjectId)'
-#            definition: '$(oneAuthTestAppPipelineId)'
-#            version: '24872218'
-#            downloadPath: '$(Build.ArtifactStagingDirectory)'
-#          env:
-#            SYSTEM_ACCESSTOKEN: $(OfficePAT)
+- stage: 'oneAuthTestApp'
+  displayName: Build OneAuth Test App Apk
+  dependsOn: []   # this removes the implicit dependency on previous stage and causes this to run in parallel
+  jobs:
+    - job: queue_build_OneAuthTestApp
+      displayName: Generate OneAuth Test App Apk
+      timeoutInMinutes: 120
+      steps:
+        - checkout: self
+          persistCredentials: True
+        - task: PowerShell@2
+          displayName: Queue and wait for OneAuth Test App Apk generation pipeline
+          name: buildApk
+          continueOnError: true
+          inputs:
+            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
+            arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -Branch "android/common-ingestion" -TemplateParams "{''androidCommonVersion'': ''$(dailyVersion)''}"'
+            workingDirectory: '$(Build.SourcesDirectory)'
+          env:
+            SYSTEM_ACCESSTOKEN: $(OfficePAT)
+        - task: DownloadExternalBuildArtifacts@15
+          displayName: 'Download OneAuth test app'
+          inputs:
+            connection: '$(oneAuthServiceConnection)'
+            project: '$(oneAuthProjectId)'
+            definition: '$(oneAuthTestAppPipelineId)'
+            version: '24872218'
+            downloadPath: '$(Build.ArtifactStagingDirectory)'
+          env:
+            SYSTEM_ACCESSTOKEN: $(OfficePAT)
 #        - publish: $(Build.ArtifactStagingDirectory)/OneAuthTestApp
 #          displayName: 'Publish OneAuth Test apk for later use'
 #          artifact: oneauthtestapp
@@ -290,6 +290,7 @@ stages:
   - msalautomationapp
   - brokers_azure_sample
   - firstpartyapps
+  - oneAuthTestApp
   - msalE2ETestApp
   - old_test_apps
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
@@ -308,9 +309,11 @@ stages:
                       /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldLTWApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/OldMsalTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(msalE2ETestApp),\
+                      /sdcard/OldOneAuthTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(oneAuthTestApp),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
                       /sdcard/BrokerHostWithoutBrokerSelection.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhostWithoutBrokerSelectionEnabled_apk),\
+                      /sdcard/OneAuthTestApp.apk=$(Pipeline.WorkSpace)/oneauthtestapp/arm64-v8a_signed_APK/$(oneAuthTestApp),\
                       /sdcard/Edge.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk),\
                       /sdcard/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\
                       /sdcard/Teams.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(teamsApk),\
@@ -327,6 +330,7 @@ stages:
     - msalautomationapplocalbrokerhost
     - brokers_azure_sample
     - firstpartyapps
+    - oneAuthTestApp
     - msalE2ETestApp
     - old_test_apps
   displayName: Running MSAL with Broker Test Plan (BrokerHost Tests) (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
@@ -347,10 +351,12 @@ stages:
                       /sdcard/OldBrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhost_apk),\
                       /sdcard/BrokerHostWithoutBrokerSelection.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhostWithoutBrokerSelectionEnabled_apk),\
                       /sdcard/OldMsalTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(msalE2ETestApp),\
+                      /sdcard/OldOneAuthTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(oneAuthTestApp),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=/home/vsts/work/1/brokerapks/$(brokerhost_apk),\
                       /data/local/tmp/test/DirectPushBrokerHost.apk=/home/vsts/work/1/brokerapks/$(brokerhost_apk),\
                       /data/local/tmp/DirectPushBrokerHost.apk=/home/vsts/work/1/brokerapks/$(brokerhost_apk),\
+                      /sdcard/OneAuthTestApp.apk=$(Pipeline.WorkSpace)/oneauthtestapp/arm64-v8a_signed_APK/$(oneAuthTestApp),\
                       /sdcard/Edge.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk),\
                       /sdcard/MsalTestApp.apk=$(Pipeline.WorkSpace)/msalE2ETestApp/$(msalE2ETestApp)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
@@ -363,6 +369,7 @@ stages:
     - msalautomationapp
     - brokers_azure_sample
     - firstpartyapps
+    - oneAuthTestApp
     - msalE2ETestApp
     - old_test_apps
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionLow }})
@@ -381,12 +388,14 @@ stages:
                       /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldltwApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/OldMsalTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(msalE2ETestApp),\
+                      /sdcard/OldOneAuthTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(oneAuthTestApp),\
                       /sdcard/BrokerHostWithoutBrokerSelection.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhostWithoutBrokerSelectionEnabled_apk),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
                       /sdcard/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\
                       /sdcard/Teams.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(teamsApk),\
                       /sdcard/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk),\
+                      /sdcard/OneAuthTestApp.apk=$(Pipeline.WorkSpace)/oneauthtestapp/arm64-v8a_signed_APK/$(oneAuthTestApp),\
                       /sdcard/Edge.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk),\
                       /sdcard/MsalTestApp.apk=$(Pipeline.WorkSpace)/msalE2ETestApp/$(msalE2ETestApp)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
@@ -399,6 +408,7 @@ stages:
   - brokerautomationapp
   - brokers_azure_sample
   - firstpartyapps
+  - oneAuthTestApp
   - old_test_apps
   displayName: ADAL with broker and Broker basic validation test plan (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
   jobs:
@@ -418,6 +428,8 @@ stages:
                       /sdcard/BrokerHostWithoutBrokerSelection.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhostWithoutBrokerSelectionEnabled_apk),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
+                      /sdcard/OneAuthTestApp.apk=$(Pipeline.WorkSpace)/oneauthtestapp/arm64-v8a_signed_APK/$(oneAuthTestApp),\
+                      /sdcard/OldOneAuthTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(oneAuthTestApp),\
                       /sdcard/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\
                       /sdcard/Teams.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(teamsApk),\
                       /sdcard/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk),\

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -238,13 +238,13 @@ stages:
             connection: '$(oneAuthServiceConnection)'
             project: '$(oneAuthProjectId)'
             definition: '$(oneAuthTestAppPipelineId)'
-            version: '24872218'
+            version: '$(buildApk.BrokeBuildId)'
             downloadPath: '$(Build.ArtifactStagingDirectory)'
           env:
             SYSTEM_ACCESSTOKEN: $(OfficePAT)
-#        - publish: $(Build.ArtifactStagingDirectory)/OneAuthTestApp
-#          displayName: 'Publish OneAuth Test apk for later use'
-#          artifact: oneauthtestapp
+        - publish: $(Build.ArtifactStagingDirectory)/OneAuthTestApp
+          displayName: 'Publish OneAuth Test apk for later use'
+          artifact: oneauthtestapp
 # Download First Party Apps
 - stage: 'firstpartyapps'
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -228,10 +228,8 @@ stages:
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -Branch "android/common-ingestion" -TemplateParams "{''androidCommonVersion'': ''$(dailyVersion)''}"'
+            arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$(OfficePAT)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -Branch "android/common-ingestion" -TemplateParams "{''androidCommonVersion'': ''$(dailyVersion)''}"'
             workingDirectory: '$(Build.SourcesDirectory)'
-          env:
-            SYSTEM_ACCESSTOKEN: $(OfficePAT)
         - task: DownloadExternalBuildArtifacts@15
           displayName: 'Download OneAuth test app'
           inputs:
@@ -240,8 +238,6 @@ stages:
             definition: '$(oneAuthTestAppPipelineId)'
             version: '$(buildApk.BrokeBuildId)'
             downloadPath: '$(Build.ArtifactStagingDirectory)'
-          env:
-            SYSTEM_ACCESSTOKEN: $(OfficePAT)
         - publish: $(Build.ArtifactStagingDirectory)/OneAuthTestApp
           displayName: 'Publish OneAuth Test apk for later use'
           artifact: oneauthtestapp

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -229,8 +229,10 @@ stages:
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$(OfficePAT)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -Branch "android/common-ingestion" -TemplateParams "{''androidCommonVersion'': ''$(dailyVersion)''}"'
+            arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -Branch "android/common-ingestion" -TemplateParams "{''androidCommonVersion'': ''$(dailyVersion)''}"'
             workingDirectory: '$(Build.SourcesDirectory)'
+          env:
+            SYSTEM_ACCESSTOKEN: $(OfficePAT)
         - task: DownloadExternalBuildArtifacts@15
           displayName: 'Download OneAuth test app'
           inputs:
@@ -239,6 +241,8 @@ stages:
             definition: '$(oneAuthTestAppPipelineId)'
             version: '24872218'
             downloadPath: '$(Build.ArtifactStagingDirectory)'
+          env:
+            SYSTEM_ACCESSTOKEN: $(OfficePAT)
         - publish: $(Build.ArtifactStagingDirectory)/OneAuthTestApp
           displayName: 'Publish OneAuth Test apk for later use'
           artifact: oneauthtestapp

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -214,11 +214,11 @@ stages:
 # TestAppApk - OneAuthTestApp Queue pipeline
 - stage: 'oneAuthTestApp'
   displayName: Build OneAuth Test App Apk
-  enabled: false
   dependsOn: []   # this removes the implicit dependency on previous stage and causes this to run in parallel
   jobs:
     - job: queue_build_OneAuthTestApp
       displayName: Generate OneAuth Test App Apk
+      enabled: false
       timeoutInMinutes: 120
       steps:
         - checkout: self

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -60,7 +60,7 @@ variables:
   LTWFeedName: Auth-Broker-Integrated-LTW-Build
   LTWApk: LTW-signed.apk
   oldLTWApk: OldLTW-signed.apk
-  oneAuthServiceConnection: OneAuth-Integration
+  oneAuthServiceConnection: OneAuthServiceConnection_3
   testAppsFeedName: AndroidADAL
   
 parameters:

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -212,40 +212,39 @@ stages:
           displayName: 'Publish Msal Test apk for later use'
           artifact: msalE2ETestApp
 # TestAppApk - OneAuthTestApp Queue pipeline
-- stage: 'oneAuthTestApp'
-  displayName: Build OneAuth Test App Apk
-  dependsOn: []   # this removes the implicit dependency on previous stage and causes this to run in parallel
-  jobs:
-    - job: queue_build_OneAuthTestApp
-      displayName: Generate OneAuth Test App Apk
-      enabled: false
-      timeoutInMinutes: 120
-      steps:
-        - checkout: self
-          persistCredentials: True
-        - task: PowerShell@2
-          displayName: Queue and wait for OneAuth Test App Apk generation pipeline
-          name: buildApk
-          continueOnError: true
-          inputs:
-            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
-            arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -Branch "android/common-ingestion" -TemplateParams "{''androidCommonVersion'': ''$(dailyVersion)''}"'
-            workingDirectory: '$(Build.SourcesDirectory)'
-          env:
-            SYSTEM_ACCESSTOKEN: $(OfficePAT)
-        - task: DownloadExternalBuildArtifacts@15
-          displayName: 'Download OneAuth test app'
-          inputs:
-            connection: '$(oneAuthServiceConnection)'
-            project: '$(oneAuthProjectId)'
-            definition: '$(oneAuthTestAppPipelineId)'
-            version: '24872218'
-            downloadPath: '$(Build.ArtifactStagingDirectory)'
-          env:
-            SYSTEM_ACCESSTOKEN: $(OfficePAT)
-        - publish: $(Build.ArtifactStagingDirectory)/OneAuthTestApp
-          displayName: 'Publish OneAuth Test apk for later use'
-          artifact: oneauthtestapp
+#- stage: 'oneAuthTestApp'
+#  displayName: Build OneAuth Test App Apk
+#  dependsOn: []   # this removes the implicit dependency on previous stage and causes this to run in parallel
+#  jobs:
+#    - job: queue_build_OneAuthTestApp
+#      displayName: Generate OneAuth Test App Apk
+#      timeoutInMinutes: 120
+#      steps:
+#        - checkout: self
+#          persistCredentials: True
+#        - task: PowerShell@2
+#          displayName: Queue and wait for OneAuth Test App Apk generation pipeline
+#          name: buildApk
+#          continueOnError: true
+#          inputs:
+#            filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
+#            arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$env:SYSTEM_ACCESSTOKEN" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -Branch "android/common-ingestion" -TemplateParams "{''androidCommonVersion'': ''$(dailyVersion)''}"'
+#            workingDirectory: '$(Build.SourcesDirectory)'
+#          env:
+#            SYSTEM_ACCESSTOKEN: $(OfficePAT)
+#        - task: DownloadExternalBuildArtifacts@15
+#          displayName: 'Download OneAuth test app'
+#          inputs:
+#            connection: '$(oneAuthServiceConnection)'
+#            project: '$(oneAuthProjectId)'
+#            definition: '$(oneAuthTestAppPipelineId)'
+#            version: '24872218'
+#            downloadPath: '$(Build.ArtifactStagingDirectory)'
+#          env:
+#            SYSTEM_ACCESSTOKEN: $(OfficePAT)
+#        - publish: $(Build.ArtifactStagingDirectory)/OneAuthTestApp
+#          displayName: 'Publish OneAuth Test apk for later use'
+#          artifact: oneauthtestapp
 # Download First Party Apps
 - stage: 'firstpartyapps'
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -225,24 +225,19 @@ stages:
         - task: PowerShell@2
           displayName: Queue and wait for OneAuth Test App Apk generation pipeline
           name: buildApk
+          enabled: false
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
             arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$(OfficePAT)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -Branch "android/common-ingestion" -TemplateParams "{''androidCommonVersion'': ''$(dailyVersion)''}"'
             workingDirectory: '$(Build.SourcesDirectory)'
-        - task: DownloadPipelineArtifact@2
-          inputs:
-            buildType: 'specific'
-            project: 'OneAuth'
-            definition: $(oneAuthTestAppPipelineId)
-            buildVersionToDownload: 'latest'
         - task: DownloadExternalBuildArtifacts@15
           displayName: 'Download OneAuth test app'
           inputs:
             connection: '$(oneAuthServiceConnection)'
             project: '$(oneAuthProjectId)'
             definition: '$(oneAuthTestAppPipelineId)'
-            version: '$(buildApk.BrokeBuildId)'
+            version: '24872218'
             downloadPath: '$(Build.ArtifactStagingDirectory)'
         - publish: $(Build.ArtifactStagingDirectory)/OneAuthTestApp
           displayName: 'Publish OneAuth Test apk for later use'

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -214,6 +214,7 @@ stages:
 # TestAppApk - OneAuthTestApp Queue pipeline
 - stage: 'oneAuthTestApp'
   displayName: Build OneAuth Test App Apk
+  enabled: false
   dependsOn: []   # this removes the implicit dependency on previous stage and causes this to run in parallel
   jobs:
     - job: queue_build_OneAuthTestApp
@@ -225,7 +226,6 @@ stages:
         - task: PowerShell@2
           displayName: Queue and wait for OneAuth Test App Apk generation pipeline
           name: buildApk
-          enabled: false
           continueOnError: true
           inputs:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
@@ -291,7 +291,6 @@ stages:
   - msalautomationapp
   - brokers_azure_sample
   - firstpartyapps
-  - oneAuthTestApp
   - msalE2ETestApp
   - old_test_apps
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
@@ -310,11 +309,9 @@ stages:
                       /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldLTWApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/OldMsalTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(msalE2ETestApp),\
-                      /sdcard/OldOneAuthTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(oneAuthTestApp),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
                       /sdcard/BrokerHostWithoutBrokerSelection.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhostWithoutBrokerSelectionEnabled_apk),\
-                      /sdcard/OneAuthTestApp.apk=$(Pipeline.WorkSpace)/oneauthtestapp/arm64-v8a_signed_APK/$(oneAuthTestApp),\
                       /sdcard/Edge.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk),\
                       /sdcard/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\
                       /sdcard/Teams.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(teamsApk),\
@@ -331,7 +328,6 @@ stages:
     - msalautomationapplocalbrokerhost
     - brokers_azure_sample
     - firstpartyapps
-    - oneAuthTestApp
     - msalE2ETestApp
     - old_test_apps
   displayName: Running MSAL with Broker Test Plan (BrokerHost Tests) (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
@@ -352,12 +348,10 @@ stages:
                       /sdcard/OldBrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhost_apk),\
                       /sdcard/BrokerHostWithoutBrokerSelection.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhostWithoutBrokerSelectionEnabled_apk),\
                       /sdcard/OldMsalTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(msalE2ETestApp),\
-                      /sdcard/OldOneAuthTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(oneAuthTestApp),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=/home/vsts/work/1/brokerapks/$(brokerhost_apk),\
                       /data/local/tmp/test/DirectPushBrokerHost.apk=/home/vsts/work/1/brokerapks/$(brokerhost_apk),\
                       /data/local/tmp/DirectPushBrokerHost.apk=/home/vsts/work/1/brokerapks/$(brokerhost_apk),\
-                      /sdcard/OneAuthTestApp.apk=$(Pipeline.WorkSpace)/oneauthtestapp/arm64-v8a_signed_APK/$(oneAuthTestApp),\
                       /sdcard/Edge.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk),\
                       /sdcard/MsalTestApp.apk=$(Pipeline.WorkSpace)/msalE2ETestApp/$(msalE2ETestApp)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
@@ -370,7 +364,6 @@ stages:
     - msalautomationapp
     - brokers_azure_sample
     - firstpartyapps
-    - oneAuthTestApp
     - msalE2ETestApp
     - old_test_apps
   displayName: Running MSAL with Broker Test Plan (API ${{ parameters.firebaseDeviceAndroidVersionLow }})
@@ -389,14 +382,12 @@ stages:
                       /sdcard/OldLTW.apk=$(Pipeline.Workspace)/brokerapks/oldAPKs/$(OldltwApk),\
                       /sdcard/OldAuthenticator.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(oldAuthenticatorApk),\
                       /sdcard/OldMsalTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(msalE2ETestApp),\
-                      /sdcard/OldOneAuthTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(oneAuthTestApp),\
                       /sdcard/BrokerHostWithoutBrokerSelection.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhostWithoutBrokerSelectionEnabled_apk),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
                       /sdcard/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\
                       /sdcard/Teams.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(teamsApk),\
                       /sdcard/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk),\
-                      /sdcard/OneAuthTestApp.apk=$(Pipeline.WorkSpace)/oneauthtestapp/arm64-v8a_signed_APK/$(oneAuthTestApp),\
                       /sdcard/Edge.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(edgeApk),\
                       /sdcard/MsalTestApp.apk=$(Pipeline.WorkSpace)/msalE2ETestApp/$(msalE2ETestApp)"
         firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
@@ -409,7 +400,6 @@ stages:
   - brokerautomationapp
   - brokers_azure_sample
   - firstpartyapps
-  - oneAuthTestApp
   - old_test_apps
   displayName: ADAL with broker and Broker basic validation test plan (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
   jobs:
@@ -429,8 +419,6 @@ stages:
                       /sdcard/BrokerHostWithoutBrokerSelection.apk=$(Pipeline.WorkSpace)/brokerapks/oldAPKs/$(brokerhostWithoutBrokerSelectionEnabled_apk),\
                       /sdcard/AzureSample.apk=$(Pipeline.Workspace)/azuresample/$(azure_sample_apk),\
                       /sdcard/BrokerHost.apk=$(Pipeline.WorkSpace)/brokerapks/$(brokerhost_apk),\
-                      /sdcard/OneAuthTestApp.apk=$(Pipeline.WorkSpace)/oneauthtestapp/arm64-v8a_signed_APK/$(oneAuthTestApp),\
-                      /sdcard/OldOneAuthTestApp.apk=$(Pipeline.WorkSpace)/oldtestapps/$(oneAuthTestApp),\
                       /sdcard/Outlook.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(outlookApk),\
                       /sdcard/Teams.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(teamsApk),\
                       /sdcard/Word.apk=$(Pipeline.WorkSpace)/firstpartyapks/$(wordApk),\

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -230,6 +230,12 @@ stages:
             filePath: '$(Build.SourcesDirectory)/azure-pipelines/scripts/queue-build.ps1'
             arguments: '-OrganizationUrl "https://office.visualstudio.com/" -Project "OneAuth" -PipelinePAT "$(OfficePAT)" -WaitTimeoutInMinutes 120 -BuildDefinitionId "$(oneAuthTestAppPipelineId)" -Branch "android/common-ingestion" -TemplateParams "{''androidCommonVersion'': ''$(dailyVersion)''}"'
             workingDirectory: '$(Build.SourcesDirectory)'
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            buildType: 'specific'
+            project: 'OneAuth'
+            definition: $(oneAuthTestAppPipelineId)
+            buildVersionToDownload: 'latest'
         - task: DownloadExternalBuildArtifacts@15
           displayName: 'Download OneAuth test app'
           inputs:


### PR DESCRIPTION
A PAT recently expired in one of the existing oneauth connections. The connection was created by tanmay, but i don't have the permissions to update it. I've created a new connection, in which i've granted admin roles to multiple people in project and organization level, this makes it easier to edit in the future.

New connection: https://identitydivision.visualstudio.com/Engineering/_settings/adminservices?resourceId=cb1685ed-b09b-4a08-8ee0-44793edc38c3

Validation run: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1225673&view=results