### PR TITLE
Update  flighted-auth-client-android-dev.yml to send flags in publish step

### DIFF
--- a/azure-pipelines/continuous-delivery/flighted-auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/flighted-auth-client-android-dev.yml
@@ -184,7 +184,7 @@ stages:
       dependencyParams:  $(common4jVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(projVersionParam) $(common4jVersionParam) $(enableBrokerDiscoveryParam) $(trustDebugBrokerParam) $(bypassRedirectUriCheckParam)
       testParams: $(projVersionParam) $(common4jVersionParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true
-      publishParams: $(projVersionParam) $(common4jVersionParam)
+      publishParams: $(projVersionParam) $(common4jVersionParam) $(enableBrokerDiscoveryParam) $(trustDebugBrokerParam) $(bypassRedirectUriCheckParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
       shouldPublish: ${{ parameters.shouldPublishLibraries }}


### PR DESCRIPTION
We need to pass flags as publish parameters for it to be available when the aar is published.  Reverting a small change made here https://github.com/AzureAD/android-complete/pull/277/files