### PR TITLE
Remove otelexporter as code is merged into AADAuthenticator

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -95,9 +95,6 @@ project(':broker4j').projectDir = new File('broker/broker4j')
 include(":LinuxBroker")
 project(':LinuxBroker').projectDir = new File('broker/LinuxBroker')
 
-include(":otelexporter")
-project(':otelexporter').projectDir = new File('broker/otelexporter')
-
 include(':LabApiUtilities')
 project(':LabApiUtilities').projectDir = new File('common/LabApiUtilities')
 


### PR DESCRIPTION
Related: https://github.com/AzureAD/ad-accounts-for-android/pull/2675