### PR TITLE
update nimbus

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -38,7 +38,7 @@ ext {
     mockitoCoreVersion = "3.6.28"
     mockitoAndroidVersion = "3.6.28"
     multidexVersion = "2.0.1"
-    nimbusVersion = "9.9"
+    nimbusVersion = "9.37.3"
     powerMockVersion = "2.0.9"
     runnerVersion = "1.2.0"
     rulesVersion = "1.2.0"


### PR DESCRIPTION
Why?
A vulnerability was found in old versions of nimbus.
see: https://nvd.nist.gov/vuln/detail/CVE-2023-52428