### PR TITLE
Revert "update nimbus"

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -38,7 +38,7 @@ ext {
     mockitoCoreVersion = "3.6.28"
     mockitoAndroidVersion = "3.6.28"
     multidexVersion = "2.0.1"
-    nimbusVersion = "9.37.3"
+    nimbusVersion = "9.9"
     powerMockVersion = "2.0.9"
     runnerVersion = "1.2.0"
     rulesVersion = "1.2.0"


### PR DESCRIPTION
This reverts commit 7710d94fb6f497e5b4450615aa0b6e708428ca81.
#301

Why?
This change is breaking CP and blocking the release.
CP cannot update the library right now, because they need to do an IP scan before updating a lib. That would usually take a couple weeks to get the results back.
And because the severity part of this vulnerability is unclear, we will move this change to April release, giving more time to CP folks do their investigation. 
