### PR TITLE
Remove Default Local Flights Parameter in Pipelines

### DIFF
--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -63,7 +63,7 @@ parameters:
   - name: flightingValueParameter
     displayName: Broker Local Flight Json-String (not active with ECS flighting)
     type: string
-    default: '{EnablePrtV3:true,EnableBrokerPowerLiftLogging:true}'
+    default: '{}'
   - name: flagsValue
     displayName: Flags to Pass (passed to all libraries)
     type: string

--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -60,7 +60,7 @@ parameters:
 - name: flightingValueParameter
   displayName: Broker Flight Json-String (not active with ECS flighting)
   type: string
-  default: '{EnablePrtV3:true,EnableBrokerPowerLiftLogging:true}'
+  default: '{}'
 - name: flagsValue
   displayName: Flags to Pass (passed to all libraries)
   type: string


### PR DESCRIPTION
Small change to remove the two flights set by default in local flight parameter for the daily and monthly pipelines. These flights have both reached %100 rollout, or are default to "true" by now.

https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1275655&view=results