### PR TITLE
Add common4jVersionParam to run Broker unit test on Dist.

### DIFF
--- a/azure-pipelines/ui-automation/broker-release.yml
+++ b/azure-pipelines/ui-automation/broker-release.yml
@@ -398,7 +398,7 @@ stages:
       publishCmd: publishAdAccountsPublicationToVsts-maven-adal-androidRepository
       dependencyParams: $(broker4jVersionParam) $(commonVersionParam) $(androidProjectDependencyParam)
       assembleParams: $(adAccountsProjVersionParam) $(broker4jVersionParam) $(commonVersionParam) $(brokerOtelAriaTokenParam) $(powerLiftApiKeyParam) $(flagVariable) $(enableBrokerSelectionParam)
-      testParams: $(adAccountsProjVersionParam) $(broker4jVersionParam) $(commonVersionParam) $(powerLiftApiKeyParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true $(flagVariable) $(enableBrokerSelectionParam)
+      testParams: $(adAccountsProjVersionParam) $(broker4jVersionParam) $(commonVersionParam) $(powerLiftApiKeyParam) -Psugar=true -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PshouldSkipLongRunningTest=true -PcodeCoverageEnabled=true $(flagVariable) $(enableBrokerSelectionParam) $(common4jVersionParam)
       publishParams: $(adAccountsProjVersionParam) $(broker4jVersionParam) $(commonVersionParam) $(flagVariable) $(enableBrokerSelectionParam)
       vstsMvnAndroidUsername: ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME
       vstsMvnAndroidAccessToken: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN


### PR DESCRIPTION
broker unit test fails because the common4j version is not provided in the parameters;
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1278722&view=logs&s=fb276794-87b9-52d2-af04-0779f3d3e350&j=73af04f5-66ca-55b9-44ad-c3a90514616d

So, we add it.

Test:
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1279973&view=logs&s=fb276794-87b9-52d2-af04-0779f3d3e350&j=d8b40171-8a63-5978-aeef-5f98ddf713e5