### PR TITLE
Update docs for labsetup

### DIFF
--- a/docs/Automation/labsetup.md
+++ b/docs/Automation/labsetup.md
@@ -18,43 +18,16 @@ The Lab Api is a protected Api and we need an access token to be able to make re
 
 **NOTE:** Please note that you must be a Microsoft employee and part of the relevant groups to be able to acquire credentials that are necessary for authenticating against the LAB API. In other words, the LAB API and the tests that utilize it are only going to run successfully if supplied with required lab credentials.
 
-### Making client credential grant request with secret
+### Making client credential grant request With Client Assertion (Certificate)
 
-**How to get access to the KeyVault where Client Secret is stored (You MAY skip this if already have access):**
+**How to get access to the KeyVault where Client Certificate is stored (You MAY skip this if already have access):**
 
 1. Go to https://coreidentity.microsoft.com/
 2. Request membership from one of the following groups:
-    - If a member of the Identity org, request read-write permissions for entitlement **TM-MSIDLabs-Int**
-    - If outside the Identity org, request read access to entitlement **TM-MSIDLABS-DevKV**
+   - If a member of the Identity org, request read-write permissions for entitlement **TM-MSIDLabs-Int**
+   - If outside the Identity org, request read access to entitlement **TM-MSIDLABS-DevKV**
 3. You can also reach out to *msidlabint@microsoft.com* to ask them for a rushed approval
 4. After access has been approved, wait for 2-24 hours for changes to be effective.
-
-**How to get the secret for accessing Lab Api:**
-
-1. Go to Azure Portal: https://portal.azure.com/ and login with MS credentials
-2. Switch to the Microsoft directory (if not already there)
-3. Search for the KeyVault named "**MSIDLABS**" (be sure to select "all" for the subcription, location etc filters) 
-4. Click into the **MSIDLABS** keyvault
-5. Under settings, click on secrets
-6. The secret we are looking for is called **LabVaultAppSecret**
-7. Get the value for this secret and copy to clipboard
-
-**How to run the tests with this secret:**
-
-To run tests with client secret, you would have to pass the following command line parameters when building/running tests.
-`-PlabSecret="<secret-value>"`
-
-**Example test execution**
-
-`./gradlew app:test -PlabSecret="<secret-value>"`
-
-**From within Android Studio**
-
-This can also be achieved from within Android Studio as follows:
-
-![Android Studio Command Line Parameters](images/android_studio_cmd_params.png "Android Studio Command Line Parameters")
-
-### With Client Assertion (Certificate)
 
 Client assertion uses a certificate, therefore we need to have a certificate installed on our local machine for us to be able to successfully create a client_assertion and be able to obtain the access token for the Lab Api. 
 This certificate is stored securely in a KeyVault that all Microsoft employees can get access to, and from there they can download it onto their local machines. 


### PR DESCRIPTION
Removing the content specific to using client secret for lab setup