### PR TITLE
Remove debug flags from scheduled daily runs

### DIFF
--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -134,11 +134,13 @@ variables:
     trustDebugBrokerParam: -PtrustDebugBrokerFlag
   ${{ else }}:
     trustDebugBrokerParam: ''
-  ${{ if parameters.treatTestAppAsPartOfTSL }}:
+  ${{ if or(parameters.treatTestAppAsPartOfTSL, eq( variables['Build.Reason'], 'Schedule')) }}:
     bypassRedirectUriCheckParam: -PbypassRedirectUriCheck
-    treatTestAppAsPartOfTSLParam: -PtreatTestAppAsPartOfTSL
   ${{ else }}:
     bypassRedirectUriCheckParam: ''
+  ${{ if parameters.treatTestAppAsPartOfTSL }}:
+    treatTestAppAsPartOfTSLParam: -PtreatTestAppAsPartOfTSL
+  ${{ else }}:
     treatTestAppAsPartOfTSLParam: ''
   brokerHostPackageVersionCounter: $[counter(1, 10000)]
 


### PR DESCRIPTION
In our daily pipeline runs, we have some boolean parameters to enable additional debugging flags as part of our validation runs. This is causing some failures, as some test cases do not behave properly when debug settings are enabled (this is expected). This PR will remove these flags from the scheduled runs.