### PR TITLE
Move Cert Template in the daily pipeline

### DIFF
--- a/azure-pipelines/templates/run-instrumented-tests.yml
+++ b/azure-pipelines/templates/run-instrumented-tests.yml
@@ -50,7 +50,6 @@ jobs:
     clean: true
     persistCredentials: True
     submodules: recursive
-  - template: ../templates/automation-cert.yml
   - script: echo "##vso[build.addbuildtag]projectVariant=$(project.variant) AndroidSystemImage=$(android.system.image)"
     displayName: Create tag
   - ${{ if ne(parameters.accessTokenKey, 'none') }}:
@@ -83,6 +82,7 @@ jobs:
 
       echo "Emulator started"
     displayName: 'Starting android emulator'
+  - template: ../templates/automation-cert.yml
   - script: |
       #!/usr/bin/env bash
       echo Push certificate to emulator


### PR DESCRIPTION
Not sure if this will work, as there's no way to test this considering the nature of the bug.

Daily pipeline is not running instrumented tests as part of scheduled runs or manual runs, but only when running on dev branch. It seems to be related to CodeQL, which is automatically injected when running on dev, but no other branch. So we won't know if this fixes the bug, until it's merged.