### PR TITLE
Fix prefix passed in LTW run

### DIFF
--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -182,7 +182,7 @@ stages:
       steps:
         - checkout: self
           persistCredentials: True
-        - script: echo "The current msal version is $(msal_sdk_version) and prefix is $(test_run_prefix)"
+        - script: echo "The current msal version is $(msal_sdk_version)"
         - task: PowerShell@2
           displayName: Queue and wait for Msal Test App Apk generation pipeline
           name: buildApk


### PR DESCRIPTION
Prefix passed in test_run_prefix variable has a space which is causing some conditions in LTW automation run to not be satisfied. Removed the unnecessary space to fix it.