### PR TITLE
Remove schedule from daily pipeline on android-complete, we should use 1ES now

### DIFF
--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -12,14 +12,6 @@ name: 1.0.$(Date:yyyyMMdd)-dev$(nameSuffix)$(Rev:.r) # $(Build.BuildNumber) = na
 pr: none
 trigger: none
 
-schedules:
-  - cron: "0 6 * * 1-6" # 6:00 AM UTC everyday Mon-Sat
-    displayName: Auth Client Android SDK dev build
-    branches:
-      include:
-      - master
-    always: true
-
 resources:
   repositories:
     - repository: common


### PR DESCRIPTION
Remove schedule from daily pipeline on android-complete, we should use 1ES now

Link to 1ES Pipeline: https://identitydivision.visualstudio.com/Engineering/_build?definitionId=2560&_a=summary
