### PR TITLE
Trigger AB#ID action on synchronize, Fixes AB#3042442

### DIFF
--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -7,7 +7,7 @@
 name: 'AB#ID Check'
 on: 
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, labeled, synchronize]
 
 jobs:
 # This action checks your pull request to make sure it is linked to a work item using AB# before you can merge.


### PR DESCRIPTION
There are instances where the PR gets blocked because this Action isn't triggered. The event keyword ensures that the action is triggered when a new change is pushed to the PR.

[AB#3042442](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3042442)