### PR TITLE
Use macOS-12 image for instrumented tests, Fixes AB#3057304

### DIFF
--- a/azure-pipelines/templates/run-instrumented-tests.yml
+++ b/azure-pipelines/templates/run-instrumented-tests.yml
@@ -37,7 +37,7 @@ jobs:
   timeoutInMinutes: ${{ parameters.timeout }}
   displayName: Run ${{ parameters.projectName }} ${{ parameters.projectVariantName }} instrumented test
   pool:
-    vmImage: macOS-latest
+    vmImage: macOS-12
   variables:
   - name: android.system.image
     value: system-images;android-${{ parameters.androidAPIlevel }};${{ parameters.androidVariant }};${{ parameters.androidABI }}


### PR DESCRIPTION
Use macOS-12 image for instrumented tests.
There seems to be some incompatibility in macOS-14, causing the android emulator to not get started.
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1370360&view=logs&j=372dca49-e22f-5a8d-7c53-02900884aa73&t=1eb2760e-f93e-51fd-5f98-ffff1c690a0f

Switching back to using macOS-12 instead of macOS-latest (which points to macOS-14)

[AB#3057304](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3057304)