### PR TITLE
Updating Protobuf, Fixes AB#3331682

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -84,6 +84,7 @@ ext {
     AndroidCredentialsVersion="1.2.2"
     LegacyFidoApiVersion="20.1.0"
     GoogleIdVersion="1.1.0"
+    protobufJavaliteVersion="3.25.5"
 
     // microsoft-diagnostics-uploader app versions
     powerliftVersion = "0.14.7"


### PR DESCRIPTION
### Summary
[AB#3331682](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3331682)

We were notified by CG of a [CVE with high severity related to protobuf](https://identitydivision.visualstudio.com/Engineering/_componentGovernance/AuthClientAndroidPipelines/alert/12112120?typeId=34726829), and the mitigation is to update to version 3.25.5.

I ran the pipeline with these changes and all our partner apps built: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1513469&view=results

AuthApp: [Already at 3.25.5](https://msazure.visualstudio.com/One/_git/AD-MFA-phonefactor-phoneApp-android?path=%2FPhoneFactor%2Fgradle.properties&_a=contents&version=GBworking)
CP: They said they are already at 3.25.5
LTW: [Already at 3.25.5](https://microsoft.visualstudio.com/OS/_git/Shell.MMX?path=%2Fandroid%2Fapps%2FYPC%2Fbuild.gradle&_a=contents&version=GBmain)
OneAuth: Shouldn't apply to them, since we only use protobuf in broker