### PR TITLE
Refine agent dispatcher and PBI dispatcher skills to prioritize PR creation over issues

### DIFF
--- a/.github/agents/agent-dispatcher.agent.md
+++ b/.github/agents/agent-dispatcher.agent.md
@@ -14,35 +14,32 @@ Read the skill file at `.github/skills/pbi-dispatcher/SKILL.md` and follow its w
 
 ## Key Rules
 
-1. **Discover gh accounts first** — follow the GitHub Account Discovery sequence in the skill:
+1. **Always create PRs, never bare issues** — The goal is to get Copilot coding agent to
+   generate a pull request with code changes. Use `create_pull_request_with_copilot` MCP
+   tool first, then `gh agent-task create` CLI, then generate a script. NEVER use
+   `gh issue create` as a dispatch mechanism.
+
+2. **Discover gh accounts first** — follow the GitHub Account Discovery sequence in the skill:
    - Check `.github/developer-local.json`
    - Fall back to `gh auth status`
    - Fall back to prompting the developer
    - **Never hardcode GitHub usernames**
 
-2. **Switch gh account** before any GitHub operations using the discovered usernames:
+3. **Switch gh account** before any GitHub operations using the discovered usernames:
    - `AzureAD/*` repos → `gh auth switch --user <discovered_public_username>`
    - `identity-authnz-teams/*` repos → `gh auth switch --user <discovered_emu_username>`
 
-2. **Read the full PBI** from ADO using `mcp_ado_wit_get_work_item` before dispatching
+4. **Read the full PBI** from ADO using `mcp_ado_wit_get_work_item` before dispatching
 
-3. **Dispatch using `gh agent-task create`** with the FULL PBI description:
-   ```powershell
-   gh auth switch --user <discovered_public_username>
-   $prompt = "<full PBI description including Fixes AB#ID>"
-   gh agent-task create $prompt --repo "OWNER/REPO" --base dev
-   ```
+5. **Dispatch priority order:**
+   - **First**: Try `create_pull_request_with_copilot` MCP tool
+   - **Second**: If MCP returns 401/403, try `gh agent-task create` CLI
+   - **Third**: If CLI unavailable (no pwsh), generate a `.ps1` script using `gh agent-task create`
+   - **NEVER**: Do NOT use `gh issue create` — issues don't trigger Copilot coding agent
 
-4. **Fallback** if `agent-task create` fails:
-   ```powershell
-   gh issue create --repo "OWNER/REPO" --title "..." --body "..."
-   # Then assign:
-   echo '{"assignees":["copilot-swe-agent[bot]"]}' | gh api /repos/OWNER/REPO/issues/NUMBER/assignees --method POST --input -
-   ```
+6. **Respect dependencies** — don't dispatch if dependent PBIs haven't been implemented yet
 
-5. **Respect dependencies** — don't dispatch if dependent PBIs haven't been implemented yet
-
-6. **Report dispatch results** back in detail. For each dispatched PBI, include:
+7. **Report dispatch results** back in detail. For each dispatched PBI, include:
    - The AB# ID
    - The target repo
    - The PR number and URL (if available from the `gh agent-task create` output)
@@ -50,4 +47,4 @@ Read the skill file at `.github/skills/pbi-dispatcher/SKILL.md` and follow its w
    
    The orchestrator will use this information to update dashboard state and artifacts.
 
-7. Return the dispatch summary with AB# IDs, repos, PR numbers (if available), and status
+8. Return the dispatch summary with AB# IDs, repos, PR numbers (if available), and status

--- a/.github/skills/pbi-dispatcher/SKILL.md
+++ b/.github/skills/pbi-dispatcher/SKILL.md
@@ -5,13 +5,30 @@ description: Dispatch Azure DevOps PBIs to GitHub Copilot coding agent for auton
 
 # PBI Dispatcher
 
-Dispatch Azure DevOps PBIs to GitHub Copilot coding agent by creating GitHub Issues in the
-target repos and assigning them to `copilot-swe-agent[bot]`.
+Dispatch Azure DevOps PBIs to GitHub Copilot coding agent by creating PRs via the
+`create_pull_request_with_copilot` GitHub MCP tool (preferred) or `gh agent-task create` CLI.
+
+**IMPORTANT**: Always create PRs, never issues. The goal is to get Copilot coding agent to
+generate a pull request with code changes — NOT to create a GitHub Issue.
+
+## Dispatch Method Priority
+
+Try these methods **in order**. Use the first one that succeeds:
+
+1. **`create_pull_request_with_copilot` MCP tool** (PREFERRED — works inside Copilot CLI)
+2. **`assign_copilot_to_issue` MCP tool** (if an issue already exists)
+3. **`gh agent-task create` CLI** (if MCP tools return 401/403 due to auth limitations)
+4. **Generate a script** for the developer to run manually (last resort)
+
+**NEVER create a bare GitHub Issue as the dispatch mechanism.** If the MCP tool fails with
+401 (EMU auth can't access public repos), fall back to generating a `gh agent-task create`
+script — NOT a `gh issue create` script.
 
 ## Prerequisites
 
 - **ADO MCP Server** running (for reading PBI details)
-- **GitHub CLI** (`gh`) authenticated with accounts for target repos
+- **GitHub MCP Server** configured (for `create_pull_request_with_copilot`)
+- **GitHub CLI** (`gh`) authenticated as fallback
 - PBIs in ADO with tag `copilot-agent-ready`
 - Copilot coding agent enabled on target repos
 
@@ -107,11 +124,31 @@ PBI description — it will be needed for the dispatch prompt.
 ### 2. Check Dependencies
 For each PBI, check if its dependencies (other AB# IDs) have merged PRs. Skip blocked PBIs.
 
-### 3. Switch gh Account + Dispatch to Copilot Agent
+### 3. Dispatch to Copilot Agent
 
-For each ready PBI:
+For each ready PBI, try these methods **in order**:
 
-**Step 1: Switch to the correct gh account** (using the discovered username from above):
+#### Method 1: `create_pull_request_with_copilot` MCP Tool (PREFERRED)
+
+This is the most direct method — it creates a PR with Copilot coding agent in one step,
+no shell commands needed:
+
+```
+create_pull_request_with_copilot(
+  owner: "AzureAD",                    // or "identity-authnz-teams" for broker
+  repo: "microsoft-authentication-library-common-for-android",
+  base_ref: "dev",
+  title: "[PBI Title]",
+  problem_statement: "<full PBI description including 'Fixes AB#ID'>"
+)
+```
+
+**If this returns 401/403** (common when GitHub MCP uses EMU auth that can't access public
+repos), fall back to Method 2.
+
+#### Method 2: `gh agent-task create` CLI
+
+**Step 1: Switch to the correct gh account** (using the discovered username):
 ```bash
 # For AzureAD/* repos (common, msal, adal):
 gh auth switch --user <discovered_public_username>
@@ -120,7 +157,7 @@ gh auth switch --user <discovered_public_username>
 gh auth switch --user <discovered_emu_username>
 ```
 
-**Step 2: Dispatch using `gh agent-task create` (PREFERRED — requires gh v2.80+):**
+**Step 2: Dispatch:**
 
 Write the full PBI description to a temp file and pipe it as the prompt. This avoids
 shell escaping issues and ensures the full context reaches the agent:
@@ -152,19 +189,23 @@ gh agent-task create (Get-Content "$env:TEMP\pbi-prompt.txt" -Raw) --repo "OWNER
 - Do NOT include local file paths (design-docs/, etc.) — the agent can't access them
 - Do NOT truncate — the full description IS the implementation spec
 
-**Step 3 (FALLBACK — if `gh agent-task create` fails):**
+**If `gh agent-task create` also fails** (not installed, pwsh unavailable), fall back to
+Method 3.
 
-Create a GitHub Issue and assign to Copilot:
-```bash
-gh issue create \
-  --repo "OWNER/REPO" \
-  --title "[PBI Title]" \
-  --body "[Full PBI description with 'Fixes AB#ID']"
+#### Method 3: Generate Script for Developer (LAST RESORT)
+
+If neither MCP tools nor `gh` CLI are available from this environment, generate a
+PowerShell script file the developer can run in their own terminal. The script MUST use
+`gh agent-task create` (NOT `gh issue create`):
+
+```powershell
+# Save to a .ps1 file for the developer:
+gh auth switch --user <discovered_public_username>
+gh agent-task create "<prompt>" --repo "OWNER/REPO" --base dev
 ```
-Then assign via API (extract issue number from the URL output):
-```bash
-echo '{"assignees":["copilot-swe-agent[bot]"],"agent_assignment":{"target_repo":"OWNER/REPO","base_branch":"dev","custom_instructions":"Follow copilot-instructions.md. PR title must include Fixes AB#ID."}}' | gh api /repos/OWNER/REPO/issues/ISSUE_NUMBER/assignees --method POST --input -
-```
+
+**NEVER generate a script that uses `gh issue create`.** Issues are not PRs — they don't
+trigger Copilot coding agent to write code.
 
 ### 4. Update ADO State
 Mark the ADO work item as `Active`, add tag `agent-dispatched`.


### PR DESCRIPTION
This pull request updates the PBI Dispatcher skill and agent documentation to enforce a new policy: Azure DevOps PBIs must be dispatched to the GitHub Copilot coding agent by creating pull requests (PRs), never bare issues. The documentation now clearly outlines the preferred dispatch methods, fallback strategies, and the strict prohibition on using GitHub Issues as a dispatch mechanism. The changes also clarify the priority order for dispatch tools and provide updated, step-by-step instructions for each method.

**Dispatch Methodology Updates:**

* The `SKILL.md` now mandates always creating PRs (never issues) when dispatching PBIs to Copilot, prioritizing the `create_pull_request_with_copilot` MCP tool, then `gh agent-task create`, and only as a last resort, generating a script for manual use. Creating issues is explicitly prohibited as it does not trigger the Copilot agent. [[1]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL8-R31) [[2]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL110-R151) [[3]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL123-R160) [[4]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL155-R209)

* The agent rules in `.agent.md` have been updated to reflect the new PR-only policy, including a new dispatch priority order and the removal of any fallback to issue creation.

**Documentation and Instructional Improvements:**

* Both the skill and agent documentation now provide clearer, step-by-step instructions for each dispatch method, including detailed fallback procedures and explicit warnings against using issues. [[1]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL110-R151) [[2]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL155-R209) [[3]](diffhunk://#diff-408580335ba9e4a64271b51b99566658b938e8fc99a31dd2a4f9ed2947cbf8d4L17-R50)

* The prerequisites section in `SKILL.md` is updated to include the need for the GitHub MCP Server and clarifies authentication requirements.

**Fallback Handling:**

* If the preferred MCP tool fails due to authentication, the documentation now instructs to fall back to `gh agent-task create`, and only if that is unavailable, to generate a script for the developer—never to create an issue. [[1]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL110-R151) [[2]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL155-R209) [[3]](diffhunk://#diff-408580335ba9e4a64271b51b99566658b938e8fc99a31dd2a4f9ed2947cbf8d4L17-R50)

**Summary of Most Important Changes:**

**Enforcement of PR-Only Dispatch Policy**
- All documentation now mandates that PBIs must be dispatched by creating PRs, not issues, to ensure the Copilot coding agent is properly triggered. [[1]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL8-R31) [[2]](diffhunk://#diff-408580335ba9e4a64271b51b99566658b938e8fc99a31dd2a4f9ed2947cbf8d4L17-R50)

**Updated Dispatch Priority and Fallback Procedures**
- The preferred method is the `create_pull_request_with_copilot` MCP tool, with clear fallback steps to `gh agent-task create` and, as a last resort, generating a script—never using issues. [[1]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL110-R151) [[2]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL155-R209) [[3]](diffhunk://#diff-408580335ba9e4a64271b51b99566658b938e8fc99a31dd2a4f9ed2947cbf8d4L17-R50)

**Improved Documentation and Step-by-Step Instructions**
- Expanded and clarified step-by-step instructions for dispatching PBIs, including authentication and dependency checks. [[1]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL110-R151) [[2]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL123-R160)

**Explicit Prohibition of Issue Creation**
- All references to using `gh issue create` as a dispatch method have been removed, and explicit warnings have been added to never use issues for dispatching PBIs to Copilot. [[1]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL8-R31) [[2]](diffhunk://#diff-aca7b25e21cd97e371fb1de1e2666814aabd28e5af46f82003c4e63cf836512dL155-R209) [[3]](diffhunk://#diff-408580335ba9e4a64271b51b99566658b938e8fc99a31dd2a4f9ed2947cbf8d4L17-R50)

**Prerequisite and Environment Clarifications**
- The prerequisites section now includes the GitHub MCP Server and clarifies authentication requirements for fallback scenarios.