### PR TITLE
Integrate Authenticator submodule into skills ecosystem

### DIFF
--- a/.github/agents/codebase-researcher.agent.md
+++ b/.github/agents/codebase-researcher.agent.md
@@ -14,7 +14,7 @@ Read the skill file at `.github/skills/codebase-researcher/SKILL.md` and follow 
 
 ## Key Rules
 
-- Search across ALL repositories: common, msal, broker, adal, 1ES-Pipelines
+- Search across ALL repositories: common, msal, broker, adal, authenticator, 1ES-Pipelines
 - Read specific line ranges, not entire files
 - Report findings with file paths and line numbers
 - Check `design-docs/` for existing related designs

--- a/.github/agents/feature-orchestrator.agent.md
+++ b/.github/agents/feature-orchestrator.agent.md
@@ -142,7 +142,7 @@ Then:
    findings — your output is the primary context for writing the design spec.
 
    Search for:
-   - Existing implementations related to this feature across all repos (MSAL, Common, Broker)
+   - Existing implementations related to this feature across all repos (MSAL, Common, Broker, Authenticator)
    - Patterns to follow (feature flags, IPC, telemetry, decorators)
    - Related design docs in design-docs/
    - Key source files and their architecture
@@ -304,6 +304,7 @@ Repo slug mapping:
 - `msal` → `AzureAD/microsoft-authentication-library-for-android`
 - `broker` → `identity-authnz-teams/ad-accounts-for-android`
 - `adal` → `AzureAD/azure-activedirectory-library-for-android`
+- `authenticator` → `AzureAD/microsoft-authenticator-for-android`
 
 **Step 3: Present results** as a table with: PR #, repo, title, status, checks, +/- lines.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,9 +14,10 @@ The **android-complete** repository contains multiple sub-repositories as separa
 * **Broker** - Brokered authentication service
 * **Common** - Shared utilities, helpers, and IPC logic
 * **OneAuth** - Library owned by another team (consumed by 1P apps like Teams, Outlook)
+* **Authenticator** - Microsoft Authenticator Android application (consumes SDK library releases)
 * **1ES-Pipelines** - Production CI/CD pipeline YAML (releases, hotfixes, validation, publishing)
 
-**Important:** When asked a question, **always search across ALL repositories** to provide comprehensive answers. Code may be duplicated or shared across these sub-repos.
+**Important:** When asked a question, **always search across ALL repositories** (including Authenticator when relevant) to provide comprehensive answers. Code may be duplicated or shared across these sub-repos.
 
 ### 1.2 Authentication Flow Architecture
 
@@ -68,9 +69,34 @@ DRI Copilot MCP tools are available for querying documentation, TSGs, and past i
 * **Common:** This repo holds shared utilities, helper functions, and **all IPC logic**. MSAL/OneAuth use this layer to communicate with Broker. Suggestions in this context should aim for reusability and generality.
 * **ADAL (Azure Active Directory Authentication Library):** Similar to MSAL, this is an authentication library, potentially an older version or specific to certain flows. When working in ADAL context, align with its patterns.
 * **OneAuth:** Third-party library owned by another team (not us). Consumed by 1P Microsoft apps like Teams, Outlook, etc. OneAuth flows start by calling `BrokerMsalController` class methods.
+* **Authenticator (Microsoft Authenticator):** The Authenticator repo contains the Microsoft Authenticator Android application. It is a multi-module Gradle project rooted at `authenticator/PhoneFactor/`. Authenticator consumes SDK library releases from MSAL, Common, and Broker as dependencies. Key modules include:
+    * **MSAuthenticator** (`authenticator/PhoneFactor/app`) — Main app entry point (MainActivity, UI, lifecycle)
+    * **MfaLibrary** (`authenticator/PhoneFactor/MfaLibrary`) — MFA SDK: push notifications, PIN encryption, device-notification validation
+    * **CtapLibrary** (`authenticator/PhoneFactor/CtapLibrary`) — FIDO2/CTAP passkey management: storage, registration, assertion
+    * **SharedCoreLibrary** (`authenticator/PhoneFactor/SharedCoreLibrary`) — Core crypto, encryption, shared utilities
+    * **SecureKeystoreLibrary** (`authenticator/PhoneFactor/SecureKeystoreLibrary`) — Secure key-pair generation (ECC/RSA) and Keystore access
+    * **NgcProviderLibrary** (`authenticator/PhoneFactor/NgcProviderLibrary`) — NGC key provider: Android Keystore-backed credential management
+    * **AadRemoteNgcLibrary** (`authenticator/PhoneFactor/AadRemoteNgcLibrary`) — AAD NGC: remote passwordless key registration/deletion
+    * **CommonUiLibrary** (`authenticator/PhoneFactor/CommonUiLibrary`) — Shared UI components, dialogs, View extensions
+    * **BastionLibrary** (`authenticator/PhoneFactor/BastionLibrary`) — Bastion validation for secure auth flows
+    * **GraphClient** (`authenticator/PhoneFactor/GraphClient`) — Microsoft Graph API client for auth methods policy
+    * **ExperimentationLibrary** (`authenticator/PhoneFactor/ExperimentationLibrary`) — ECS feature-flag provider integration
+    * **MsaAccountLibrary** (`authenticator/PhoneFactor/MsaAccountLibrary`) — MSA ticket acquisition and account operations
+    * **WalletLibrary** (`authenticator/PhoneFactor/WalletLibrary/walletlibrary`) — Entra Verified ID wallet
+    * **VerifiableCredential-SDK** (`authenticator/PhoneFactor/VerifiableCredential-SDK/sdk`) — DID SDK: verifiable credential issuance/presentation
+    * **LocationLibrary** (`authenticator/PhoneFactor/LocationLibrary`) — GPS-signal UI for conditional-access scenarios
+    * **RootDetectionLibrary** (`authenticator/PhoneFactor/RootDetectionLibrary`) — Rooted device detection and telemetry
+    * **ScanQrCodeLibrary** (`authenticator/PhoneFactor/ScanQrCodeLibrary`) — QR code scanning
+    * **AuthenticatorPolicyChannel** (`authenticator/PhoneFactor/AuthenticatorPolicyChannel`) — Credential policy enforcement
+    * **AuthenticatorSignalsLibrary** (`authenticator/PhoneFactor/AuthenticatorSignalsLibrary`) — Credential history signals for risk assessment
+    * **SilentNotificationChannelLibrary** (`authenticator/PhoneFactor/SilentNotificationChannelLibrary`) — Silent push for background MFA approval
+    * **NativeLibrary** (`authenticator/PhoneFactor/NativeLibrary`) — Native crash reporting via Breakpad
+    * **TestUtilitiesLibrary** / **AndroidTestUtilitiesLibrary** — Unit and instrumented test helpers
+    * **uiautomator-tests** (`authenticator/PhoneFactor/uiautomator-tests`) — UI Automator E2E smoke tests
+  Authenticator is an **opt-in** submodule (controlled by `includeAuthenticatorApp=true` in `gradle.properties` or `local.properties`). When working in Authenticator context, note that it has its own build conventions, dependencies, and Kotlin/Java mix.
 * **1ES-Pipelines (AuthClientAndroidPipelines):** This directory contains all 1ES-compliant production pipeline YAML for the Android Auth platform. It includes monthly release orchestrators, hotfix pipelines, daily validation, internal/external publishing, and reusable YAML templates. Files are organized into `production/`, `non-production/`, `scripts/`, and `templates/` directories. This is NOT the same as `azure-pipelines/` which contains legacy/deprecated pipeline code. When modifying pipelines, always work in `1ES-Pipelines/`. All pipeline code is YAML. See the `release-helper` skill for detailed pipeline documentation.
 
-**Important:** When generating code that interacts across these repositories (e.g., calling a function from `common` in `MSAL`), ensure the generated code respects the language and API boundaries of each repository.
+**Important:** When generating code that interacts across these repositories (e.g., calling a function from `common` in `MSAL`, or consuming SDK APIs from Authenticator), ensure the generated code respects the language and API boundaries of each repository.
 
 ## 4. Naming Conventions & Style (Kotlin First)
 
@@ -145,7 +171,7 @@ This project supports an AI-driven development workflow:
 2. **Plan**: After design approval, use the `feature-planner` skill to decompose the approved design into repo-targeted PBIs. Developer reviews and approves the plan.
 3. **Backlog**: After plan approval, use the `pbi-creator` skill to discover ADO defaults (area path, iteration) and create work items in ADO with dependency links.
 4. **Dispatch**: Use the `pbi-dispatcher` skill or `scripts/agent-pipeline/orchestrate.py` to assign PBIs to GitHub Copilot coding agent
-5. **Implement**: Copilot coding agent creates PRs in the target repos (`msal`, `common`, `broker`, `adal`)
+5. **Implement**: Copilot coding agent creates PRs in the target repos (`msal`, `common`, `broker`, `adal`, `authenticator`)
 6. **Review**: Use `@copilot` in PR comments for automated feedback iteration
 
 ### 13.2 Design Docs
@@ -158,6 +184,7 @@ The `design-docs/` folder contains the `AuthLibrariesApiReview` ADO repo (cloned
 | msal | `AzureAD/microsoft-authentication-library-for-android` |
 | broker / broker4j | `identity-authnz-teams/ad-accounts-for-android` (GHE) |
 | adal | `AzureAD/azure-activedirectory-library-for-android` |
+| authenticator | `AzureAD/microsoft-authenticator-for-android` |
 | 1ES-Pipelines | `IdentityDivision/Engineering/_git/AuthClientAndroidPipelines` (ADO) |
 
 ### 13.3 1ES-Pipelines

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -161,6 +161,26 @@ For complex investigation tasks, use these skills (read the skill file for detai
 | **threat-modeler** | `.github/skills/threat-modeler/SKILL.md` | "create a threat model", "threat model for", "threat model diagram", "STRIDE analysis for", "security diagram for" |
 | **copilot-review-analyst** | `.github/skills/copilot-review-analyst/SKILL.md` | "analyze Copilot reviews", "Copilot review effectiveness", "review analysis report", "how helpful are Copilot reviews" |
 
+### 12.1 Authenticator-Specific Skills
+
+The Authenticator submodule ships its own skills at `authenticator/.github/skills/`, loaded via `chat.agentSkillsLocations` in `.vscode/settings.json`. These skills are tuned for the Authenticator codebase and may leverage MCP tools specific to that repo (e.g., BlueBird).
+
+| Skill | Location | Purpose |
+|-------|----------|---------|
+| **android-feature-development** | `authenticator/.github/skills/android-feature-development/SKILL.md` | Feature implementation, EcsFlight feature flags, code changes |
+| **android-ui-development** | `authenticator/.github/skills/android-ui-development/SKILL.md` | UI development, Compose, colors, theming |
+| **codebase-researcher** | `authenticator/.github/skills/codebase-researcher/SKILL.md` | Deep Authenticator codebase research with architecture reference |
+| **incident-investigator** | `authenticator/.github/skills/incident-investigator/SKILL.md` | Authenticator-specific incident investigation with log patterns |
+| **pr-reviewer** | `authenticator/.github/skills/pr-reviewer/SKILL.md` | Authenticator PR review with security checklist |
+| **prompt-refiner** | `authenticator/.github/skills/prompt-refiner/SKILL.md` | Prompt refinement with Authenticator-specific templates |
+| **skill-creator** | `authenticator/.github/skills/skill-creator/SKILL.md` | Creating new skills for the Authenticator repo |
+
+**Skill Scoping — Avoiding Clashes:**  
+Four skills share names across both directories: `codebase-researcher`, `incident-investigator`, `prompt-refiner`, and `skill-creator`. Apply these rules:
+- **When working on Authenticator code** (files under `authenticator/`), prefer the Authenticator-specific skill variant (`authenticator/.github/skills/`). It has deeper context on Authenticator module structure, feature flags, and MCP integrations.
+- **When working on SDK libraries** (MSAL, Broker, Common, ADAL) or **cross-repo tasks**, use the android-complete skill variant (`.github/skills/`). It has broader multi-repo awareness and SDK-level context.
+- **When the scope is ambiguous**, use the android-complete variant as the default since it covers the full multi-repo project.
+
 ## 13. Azure DevOps Integration
 
 This project uses Azure DevOps (`IdentityDivision/Engineering`). The **Azure DevOps MCP Server** is configured in `.vscode/mcp.json` for work item management. Always check to see if the Azure DevOps MCP server has a tool relevant to the user's request.

--- a/.github/prompts/feature-pr-iterate.prompt.md
+++ b/.github/prompts/feature-pr-iterate.prompt.md
@@ -46,6 +46,7 @@ Repo slug mapping:
 - `msal` → `AzureAD/microsoft-authentication-library-for-android`
 - `broker` → `identity-authnz-teams/ad-accounts-for-android`
 - `adal` → `AzureAD/azure-activedirectory-library-for-android`
+- `authenticator` → `AzureAD/microsoft-authenticator-for-android`
 
 Discover the GitHub username from `.github/developer-local.json`, or `gh auth status`.
 Switch account before any gh commands: `gh auth switch --user <username>`
@@ -126,7 +127,7 @@ askQuestion({
 ```powershell
 gh pr checkout <prNumber> --repo "<full-repo-slug>"
 ```
-Run this in the correct sub-repo directory (common/, msal/, broker/, adal/).
+Run this in the correct sub-repo directory (common/, msal/, broker/, adal/, authenticator/).
 Then tell the developer: "Branch checked out. Make your changes, commit, and push."
 
 **If "I'll write custom feedback"**: Ask the developer to type their feedback, then post it

--- a/.github/prompts/feature-status.prompt.md
+++ b/.github/prompts/feature-status.prompt.md
@@ -27,6 +27,7 @@ Repo slug mapping:
 - `msal` → `AzureAD/microsoft-authentication-library-for-android`
 - `broker` → `identity-authnz-teams/ad-accounts-for-android`
 - `adal` → `AzureAD/azure-activedirectory-library-for-android`
+- `authenticator` → `AzureAD/microsoft-authenticator-for-android`
 
 Discover the GitHub username from `.github/developer-local.json`, or `gh auth status`, or prompt.
 

--- a/.github/skills/codebase-researcher/SKILL.md
+++ b/.github/skills/codebase-researcher/SKILL.md
@@ -18,9 +18,10 @@ This workspace contains multiple sub-repositories:
 | **Common** | Shared utilities + IPC logic | `common/common/src/main/java/com/microsoft/identity/common/` |
 | **ADAL** | Legacy auth library | `adal/adal/src/main/java/com/microsoft/aad/adal/` |
 | **OneAuth** | 1P apps library (external) | `oneauth/` |
+| **Authenticator** | Microsoft Authenticator app | `authenticator/PhoneFactor/app/`, `authenticator/PhoneFactor/MfaLibrary/`, `authenticator/PhoneFactor/SharedCoreLibrary/` |
 | **1ES-Pipelines** | Production CI/CD pipeline YAML | `1ES-Pipelines/production/`, `1ES-Pipelines/templates/`, `1ES-Pipelines/scripts/` |
 
-**⚠️ CRITICAL: Always search across ALL repositories.** Code is often duplicated or shared.
+**⚠️ CRITICAL: Always search across ALL repositories** (including Authenticator when relevant)**.** Code is often duplicated or shared.
 
 ## Authentication Flow
 
@@ -34,7 +35,7 @@ Client App → MSAL/OneAuth → Common (IPC) → Broker → eSTS → Broker → 
 2. **Always cite sources** - Every finding must include file path and line numbers
 3. **Acknowledge gaps** - Explicitly state when something cannot be found
 4. **Rate confidence** - Assign HIGH/MEDIUM/LOW to each finding
-5. **Search all modules** - Check MSAL, Broker, Common, ADAL, and 1ES-Pipelines for each query
+5. **Search all modules** - Check MSAL, Broker, Common, ADAL, Authenticator, and 1ES-Pipelines for each query
 
 ## Research Workflow
 
@@ -75,7 +76,7 @@ Use the output format below.
 ### Findings
 
 #### Finding 1: [Brief description]
-- **Module**: MSAL | Broker | Common | ADAL | 1ES-Pipelines
+- **Module**: MSAL | Broker | Common | ADAL | Authenticator | 1ES-Pipelines
 - **File**: [path/to/file.ext](path/to/file.ext#L10-L25)
 - **Confidence**: HIGH | MEDIUM | LOW
 - **Evidence**: [What makes this the right code]
@@ -119,6 +120,19 @@ Use the output format below.
 - `BrokerOperationExecutor` (Common) - Executes broker operations
 - `MsalBrokerResultAdapter` (Common) - Converts results for IPC
 - `BrokerResult` (Common) - IPC response object
+
+### Authenticator App
+- `MSAuthenticator` (`authenticator/PhoneFactor/app`) - Main app entry point (MainActivity, UI, lifecycle)
+- `MfaLibrary` (`authenticator/PhoneFactor/MfaLibrary`) - MFA push notifications, PIN encryption, device-notification validation
+- `CtapLibrary` (`authenticator/PhoneFactor/CtapLibrary`) - FIDO2/CTAP passkey management: storage, registration, assertion
+- `SharedCoreLibrary` (`authenticator/PhoneFactor/SharedCoreLibrary`) - Core crypto, encryption, shared utilities
+- `SecureKeystoreLibrary` (`authenticator/PhoneFactor/SecureKeystoreLibrary`) - Secure key-pair generation (ECC/RSA) and Keystore access
+- `NgcProviderLibrary` (`authenticator/PhoneFactor/NgcProviderLibrary`) - NGC key provider: Android Keystore-backed credential management
+- `AadRemoteNgcLibrary` (`authenticator/PhoneFactor/AadRemoteNgcLibrary`) - AAD NGC: remote passwordless key registration/deletion
+- `WalletLibrary` (`authenticator/PhoneFactor/WalletLibrary/walletlibrary`) - Entra Verified ID wallet
+- `GraphClient` (`authenticator/PhoneFactor/GraphClient`) - Microsoft Graph API client
+
+**Note:** Authenticator is an **opt-in** submodule (`includeAuthenticatorApp=true` in `gradle.properties`). It consumes SDK library releases from MSAL, Common, and Broker as dependencies — it does NOT consume source-level code from them during normal builds.
 
 ## Data Flow Investigation
 
@@ -276,7 +290,7 @@ When investigating CI/CD pipelines, release processes, or build issues:
 
 | Anti-Pattern | Problem | Correct Approach |
 |--------------|---------|------------------|
-| Searching only one module | Miss cross-module code | Search MSAL, Broker, Common, ADAL, 1ES-Pipelines |
+| Searching only one module | Miss cross-module code | Search MSAL, Broker, Common, ADAL, Authenticator, 1ES-Pipelines |
 | "This is likely in..." | Speculation without evidence | Search first, report only what's found |
 | Path without line numbers | Imprecise, hard to verify | Always include line numbers |
 | Stopping at field definition | Misses conditional logic | Trace to Builder/Adapter for full behavior |

--- a/.github/skills/copilot-review-analyst/SKILL.md
+++ b/.github/skills/copilot-review-analyst/SKILL.md
@@ -22,6 +22,7 @@ Default repos (update in scripts if changed):
 | common | `AzureAD/microsoft-authentication-library-common-for-android` | EMU (also accessible via personal) |
 | msal | `AzureAD/microsoft-authentication-library-for-android` | EMU (also accessible via personal) |
 | broker | `identity-authnz-teams/ad-accounts-for-android` | EMU only |
+| authenticator | `AzureAD/microsoft-authenticator-for-android` | EMU (also accessible via personal) |
 
 ## Analysis Pipeline
 

--- a/.github/skills/design-author/SKILL.md
+++ b/.github/skills/design-author/SKILL.md
@@ -30,7 +30,7 @@ Follow the repo's template at `design-docs/Template/template.md`. Key sections:
 
 1. **Title** — Feature name
 2. **Applicable to and priority** — Platform table (focus on Android column)
-3. **Components** — Which repos/modules (MSAL, Common, Broker, etc.)
+3. **Components** — Which repos/modules (MSAL, Common, Broker, Authenticator, etc.)
 4. **Problem description** — User problem, business context, examples
 5. **Requirements (Must)** — Key functional requirements
 6. **System Qualities (Must)** — Performance, telemetry, security, supportability
@@ -46,7 +46,7 @@ For Android-specific designs, also include:
 - **Telemetry** — Span names, attributes, success/failure signals
 - **Testing strategy** — Unit test approach, instrumented test needs, E2E coverage
 - **Rollout plan** — Feature flag stages, ECS configuration
-- **Cross-repo impact** — Which repos need changes and in what order
+- **Cross-repo impact** — Which repos need changes and in what order (include Authenticator if the feature affects the Authenticator app)
 
 ## Workflow
 
@@ -62,7 +62,7 @@ Gather from the developer:
 
 Use the `codebase-researcher` skill to:
 - Understand how related functionality currently works
-- Identify which repos/files would be affected
+- Identify which repos/files would be affected (including Authenticator if the feature touches the app)
 - Find existing patterns to follow (feature flags, error handling, telemetry, IPC contracts)
 - Check for any existing design docs in `design-docs/` on the same topic
 

--- a/.github/skills/feature-planner/SKILL.md
+++ b/.github/skills/feature-planner/SKILL.md
@@ -29,6 +29,7 @@ Determine which repo(s) each PBI targets based on the architectural layer:
 | broker | `identity-authnz-teams/ad-accounts-for-android` | Broker-side auth processing, PRT acquisition/rotation, device registration, eSTS communication, IPC entry points |
 | broker4j | (same repo as broker) | Pure Java/Kotlin broker business logic, Protobuf schemas |
 | adal | `AzureAD/azure-activedirectory-library-for-android` | Legacy ADAL changes only (rare — maintenance mode, bug fixes only) |
+| authenticator | `AzureAD/microsoft-authenticator-for-android` | Microsoft Authenticator app changes: MFA flows, passkey/FIDO2, passwordless (NGC), Verified ID wallet, UI, QR scanning, device policy, experimentation flags |
 | 1ES-Pipelines | `IdentityDivision/Engineering/_git/AuthClientAndroidPipelines` (ADO) | Pipeline YAML changes: release orchestration, hotfix pipelines, templates, validation, publishing, scripts |
 
 **Routing heuristic:**
@@ -36,7 +37,8 @@ Determine which repo(s) each PBI targets based on the architectural layer:
 2. If it's a client-facing API change or MSAL configuration → `msal`
 3. If it handles token processing on the broker side, PRT, device registration → `broker`
 4. If it's a pure Java utility with no Android dependency → `common4j` or `broker4j`
-5. Most features span `common` + one consumer (`msal` or `broker`) — create separate PBIs for each
+5. If it changes the Authenticator app (MFA, passkeys, NGC, wallet, UI) → `authenticator`
+6. Most features span `common` + one consumer (`msal`, `broker`, or `authenticator`) — create separate PBIs for each
 
 ## Workflow
 
@@ -211,7 +213,7 @@ Most bug fixes and small features only touch one repo. Create a single PBI.
 ### Two-Repo Feature (Common + Consumer)
 The most common multi-repo pattern:
 1. PBI-1: Add shared logic/contract in `common`
-2. PBI-2: Consume from `msal` or `broker`
+2. PBI-2: Consume from `msal`, `broker`, or `authenticator`
 
 ### Three-Repo Feature (Common + Broker + MSAL)
 For end-to-end features affecting the full auth flow:
@@ -219,6 +221,20 @@ For end-to-end features affecting the full auth flow:
 2. PBI-2: Implement broker-side processing (depends on PBI-1)
 3. PBI-3: Implement MSAL client-side API (depends on PBI-1)
 4. PBI-4: (optional) Integration test PBI
+
+### Authenticator Feature
+For features that also require Authenticator app changes:
+1. SDK PBIs first (common → broker/msal) — Authenticator consumes SDK library releases
+2. PBI-N: Implement Authenticator-side changes (depends on SDK PBIs)
+Authenticator targets the `AzureAD/microsoft-authenticator-for-android` repo. It is a multi-module
+Gradle project rooted at `authenticator/PhoneFactor/`. Key modules to target:
+- **MSAuthenticator** (`app/`) — Main app entry point, Activities, UI
+- **MfaLibrary** — MFA push notification flows
+- **CtapLibrary** — FIDO2/CTAP passkey operations
+- **SharedCoreLibrary** — Core crypto, encryption, shared utilities
+- **NgcProviderLibrary** / **AadRemoteNgcLibrary** — Passwordless NGC key management
+- **WalletLibrary** — Entra Verified ID wallet
+- **CommonUiLibrary** — Shared UI components
 
 ### Feature Flag Convention
 All PBIs for a feature should use the **same feature flag name** across repos:

--- a/.github/skills/feature-planner/references/pbi-template.md
+++ b/.github/skills/feature-planner/references/pbi-template.md
@@ -16,7 +16,7 @@ description and the repo's `copilot-instructions.md`.
 <table>
   <tr><td><strong>Repo</strong></td><td>[org/repo-name]</td></tr>
   <tr><td><strong>Base Branch</strong></td><td>dev</td></tr>
-  <tr><td><strong>Module</strong></td><td>[common | common4j | msal | AADAuthenticator | broker4j | adal | 1ES-Pipelines]</td></tr>
+  <tr><td><strong>Module</strong></td><td>[common | common4j | msal | AADAuthenticator | broker4j | adal | authenticator | 1ES-Pipelines]</td></tr>
 </table>
 
 <h2>Context</h2>

--- a/.github/skills/incident-investigator/SKILL.md
+++ b/.github/skills/incident-investigator/SKILL.md
@@ -159,6 +159,21 @@ State explicitly what's NOT in the logs that would help:
 - `Found more than one account entry for user`
 - Multiple accounts with same UPN but different home account IDs
 
+### Pattern: Authenticator App Issues
+**Symptoms**: MFA push notification failures, passwordless sign-in failures, passkey registration errors
+**Evidence to look for**:
+- `com.azure.authenticator` in `calling_package_name` or `active_broker_package_name`
+- NGC key registration/deletion failures in `AadRemoteNgcLibrary` logs
+- FIDO2/CTAP assertion errors from `CtapLibrary`
+- Push notification delivery failures in `MfaLibrary` logs
+- Wallet/Verified ID credential issuance or presentation errors
+**Key Authenticator modules to check:**
+- **MfaLibrary** — MFA push notification registration, PIN encryption, device-notification validation
+- **CtapLibrary** — FIDO2/CTAP passkey management
+- **NgcProviderLibrary** / **AadRemoteNgcLibrary** — Passwordless NGC key operations
+- **SharedCoreLibrary** — Core crypto and encryption
+- **SecureKeystoreLibrary** — Keystore access layer for key-pair generation
+
 ## DRI Copilot Queries
 
 ### Initial Query (always start here)

--- a/.github/skills/pbi-dispatcher/SKILL.md
+++ b/.github/skills/pbi-dispatcher/SKILL.md
@@ -97,6 +97,7 @@ Do NOT attempt to proceed without valid accounts — fail fast with clear instru
 | msal | `AzureAD/microsoft-authentication-library-for-android` | Public (AzureAD) |
 | broker / broker4j / AADAuthenticator | `identity-authnz-teams/ad-accounts-for-android` | EMU (identity-authnz-teams) |
 | adal | `AzureAD/azure-activedirectory-library-for-android` | Public (AzureAD) |
+| authenticator | `AzureAD/microsoft-authenticator-for-android` | Public (AzureAD) |
 
 ## Workflow
 

--- a/.github/skills/release-helper/SKILL.md
+++ b/.github/skills/release-helper/SKILL.md
@@ -18,6 +18,8 @@ Pipeline code lives in **two locations**:
 
 > **Key rule:** `AuthClientAndroidPipelines` is the source of truth for production pipelines. `android-complete` contains release scripts consumed by AuthClientAndroidPipelines and legacy dev-build pipelines.
 
+> **Authenticator note:** The Authenticator app (`authenticator/`) has its own separate build and release pipelines managed outside of `AuthClientAndroidPipelines`. Authenticator consumes SDK library releases (MSAL, Common, Broker) as Gradle dependencies — it does not ship as part of the SDK monthly release cycle. When SDK libraries are released, Authenticator picks up the new versions via dependency updates.
+
 ## Pipeline Catalog (Quick Reference)
 
 ### Production Pipelines (AuthClientAndroidPipelines)

--- a/.github/skills/test-planner/SKILL.md
+++ b/.github/skills/test-planner/SKILL.md
@@ -71,6 +71,16 @@ For any broker feature, cover (in order of priority):
 
 Not every feature needs all categories. Use judgment based on what the feature touches.
 
+For **Authenticator app features**, also consider:
+- **MFA push approval** (accept/deny notification) — P0
+- **Passwordless sign-in** (NGC key registration, phone sign-in) — P0
+- **Passkey/FIDO2** (registration, assertion, cross-device) — P0
+- **QR code scanning** — P1
+- **Verified ID** (credential issuance, presentation) — P1
+- **Account management** (add/remove accounts, MSA + AAD) — P1
+- **Device policy** (rooted device detection, conditional access) — P1
+- **Biometric/PIN unlock** — P1
+
 ### Get Feature Context
 
 If the user hasn't provided feature details, gather them by:

--- a/.github/skills/threat-modeler/SKILL.md
+++ b/.github/skills/threat-modeler/SKILL.md
@@ -12,7 +12,7 @@ Create threat model diagrams from feature descriptions. The AI researches the co
 ### Step 1: Understand the Feature
 
 Research the feature using the codebase-researcher skill or subagent. Identify:
-- **Processes**: Components that process data (Broker, MSAL, Chrome, eSTS)
+- **Processes**: Components that process data (Broker, MSAL, Chrome, eSTS, Authenticator)
 - **Data stores**: Where tokens/keys are persisted
 - **External interactors**: Systems outside our control
 - **Trust boundaries**: App sandboxes, device boundary, network boundary

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ build/
 .idea
 .vscode/*
 !.vscode/mcp.json
+!.vscode/settings.json
 extensions/feature-orchestrator/.vscode/
 extensions/feature-orchestrator/*.vsix
 .settings

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -8,8 +8,13 @@
     }
   ],
   "servers": {
-    // MCP Server Configuration for Microsoft Authenticator Android
+    // MCP Server Configuration for Android Auth Client
     // Docs: https://code.visualstudio.com/docs/copilot/chat/mcp-servers
+    //
+    // Bluebird MCP servers (bluebirdrepos & bluebirdrepos2) are automatically
+    // provided by the Bluebird extension (bluebird-ai-labs.bluebird-vscode).
+    // No configuration needed here — just install the extension.
+    // See .vscode/extensions.json for the recommended extension.
 
     "ado": {
       "type": "stdio",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "chat.agentSkillsLocations": [
+    ".github/skills",
+    "authenticator/.github/skills"
+  ]
+}


### PR DESCRIPTION
Add Authenticator (Microsoft Authenticator app) across all skills, agents, and prompt files to enable agentic work item completion for Authenticator code changes.

Changes:
- copilot-instructions.md: Add Authenticator to repo organization, repo- specific guidelines with full module catalog, and repository routing table
- codebase-researcher: Add Authenticator to repo structure table, key classes section, search scope, and anti-patterns
- feature-planner: Add authenticator to repo routing table with routing heuristic, and new Authenticator Feature common pattern
- design-author: Include Authenticator in components and cross-repo impact
- incident-investigator: Add Authenticator App Issues pattern with module reference for MFA, passkey, NGC, and crypto troubleshooting
- pbi-dispatcher: Add authenticator repo routing entry
- release-helper: Add note about Authenticator's separate release cycle
- test-planner: Add Authenticator-specific test scenario categories
- copilot-review-analyst: Add authenticator repo to analysis scope
- threat-modeler: Add Authenticator to process components
- pbi-template: Add authenticator as valid module target
- Agent files: Update codebase-researcher and feature-orchestrator agents with Authenticator search scope and repo slug mapping
- Prompt files: Update feature-status and feature-pr-iterate with Authenticator repo slug mapping