### PR TITLE
Skip substitution for 'dist' flavor configurations, Fixes AB#3586331

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:${rootProject.ext.gradleVersion}"
         classpath "org.javassist:javassist:${rootProject.ext.javaAssistVersion}"
-        classpath "com.microsoft.intune.mam:android-build-plugin:${rootProject.ext.intuneAppSdkVersion}"
+    //    classpath "com.microsoft.intune.mam:android-build-plugin:${rootProject.ext.intuneAppSdkVersion}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${rootProject.ext.kotlinVersion}"
     //    classpath "net.serenity-bdd:serenity-gradle-plugin:1.9.6"
     //    classpath 'com.google.gms:google-services:3.2.1'
@@ -278,7 +278,13 @@ allprojects {
 
     // Dependency substitution: when building in android-complete, replace Maven artifacts
     // with their local project equivalents to avoid duplicate class / resource errors.
+    // Note: Skip substitution for 'dist' flavor configurations — those are intended to
+    // resolve remote artifacts (e.g. distApi dependencies in test apps).
     configurations.configureEach {
+        // Skip dist flavor configurations so they resolve remote Maven artifacts
+        if (name.toLowerCase().contains('dist')) {
+            return
+        }
         resolutionStrategy.dependencySubstitution {
             if (rootProject.findProject(':AADAuthenticator') != null) {
                 substitute module('com.microsoft.workplace:ad-accounts-for-android') using project(':AADAuthenticator')

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:${rootProject.ext.gradleVersion}"
         classpath "org.javassist:javassist:${rootProject.ext.javaAssistVersion}"
-    //    classpath "com.microsoft.intune.mam:android-build-plugin:${rootProject.ext.intuneAppSdkVersion}"
+        classpath "com.microsoft.intune.mam:android-build-plugin:${rootProject.ext.intuneAppSdkVersion}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${rootProject.ext.kotlinVersion}"
     //    classpath "net.serenity-bdd:serenity-gradle-plugin:1.9.6"
     //    classpath 'com.google.gms:google-services:3.2.1'


### PR DESCRIPTION
[AB#3586331](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3586331)

Root cause: In build.gradle (root), configurations.configureEach applied a dependencySubstitution rule to every configuration — including distDebugCompileClasspath. This caused the dist flavor's distApi("com.microsoft.identity:common:24.2.0-RC1-local-flights") dependency to be silently redirected to the local :common project, which has no dist variant, causing the build failure.
Fix: Added an early return guard inside configurations.configureEach to skip the substitution block for any configuration whose name contains dist. This lets dist flavor configurations resolve com.microsoft.identity:common from the remote Maven repository as intended, while local flavor configurations continue to use the local project substitution.