### PR TITLE
Migrate DRI MCP tools from MyDRICopilot to android-dri-search, Fixes AB#3601970

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,10 +48,17 @@ Client App
 - **Common Module:** Contains all IPC (Inter-Process Communication) logic. MSAL/OneAuth use Common layer to send requests to Broker over IPC
 - **Broker Module:** Handles the actual authentication logic, communicates with eSTS, and returns tokens
 
-### 1.3 DRI Copilot MCP Server
+### 1.3 Android DRI MCP Server
 
-DRI Copilot MCP tools are available for querying documentation, TSGs, and past incidents:
-- **Broker DRI Copilot** (tools containing `Broker_DRI_Copilot`) - For Broker-related questions, PRT, device registration, brokered auth flows
+The `android-dri-search` MCP server provides tools for querying past incidents, TSGs, and DRI knowledge:
+
+| Tool | Purpose |
+|------|---------|
+| `mcp_android-dri-s2_get_incident` | Fetch a specific IcM incident by ID |
+| `mcp_android-dri-s2_batch_search` | Run multiple ICM and/or TSG searches in parallel |
+| `mcp_android-dri-s2_search_tsgs` | Search troubleshooting guides (single query) |
+
+The server is configured in `.vscode/mcp.json` as `android-dri-search`. Authentication is automatic via Entra ID OAuth — you must be a member of the **Android Auth Client SDK** security group. See `android_dri_mcp_server/deployment-and-connection-guide.md` for details.
 
 > **For incident investigations:** Use the `incident-investigator` skill (located at `.github/skills/incident-investigator/SKILL.md`) which provides a comprehensive workflow for IcM/customer-reported issues.
 

--- a/.github/skills/aria-alert-investigator/SKILL.md
+++ b/.github/skills/aria-alert-investigator/SKILL.md
@@ -113,14 +113,17 @@ If the user picks "I don't know," pick the candidate with the strongest evidence
 
 ### Step 2 — Search for past ICMs in the metric family (parallel with Step 3)
 
-The IcM's "duplicate of …" links from Step 1 capture what was already noted. This step goes further: actively search the DRI Copilot index for past Aria alerts on the **same or sibling** metrics, even if they aren't linked from the current ticket.
+The IcM's "duplicate of …" links from Step 1 capture what was already noted. This step goes further: actively search the `android-dri-search` MCP server for past Aria alerts on the **same or sibling** metrics, even if they aren't linked from the current ticket.
 
 Skip this step only if Step 1 already surfaced 3+ past ICMs in the same metric family with consistent resolutions.
 
+Use `tool_search` with query `android-dri-s` to load the tools, then call `batch_search`:
+
 ```
-mcp_mydricopilot_Android_DRI_Copilot_Project_Explorer(
-  message="Find past Aria alert ICMs related to <metric_name> in <project>. For each, return root cause, mitigation, and whether it required code change."
-)
+mcp_android-dri-s2_batch_search(searches=[
+  {"type": "icm", "query": "Aria alert <metric_name> <project>"},
+  {"type": "icm", "query": "Aria detected incident <metric_name> anomaly"}
+])
 ```
 
 Report what the family pattern looks like (do not draw conclusions about the current ICM from it).
@@ -193,8 +196,15 @@ Example:
 
 ## Tool reference
 
-### DRI Copilot
-- `mcp_mydricopilot_Android_DRI_Copilot_Project_Explorer` — Get IcM context, find similar past ICMs, search TSGs
+### Android DRI MCP Server (`android-dri-search`)
+
+| Tool | Purpose | Key Parameters |
+|------|---------|-----------------|
+| `mcp_android-dri-s2_get_incident` | Fetch incident details by ID | `incident_id` (required) |
+| `mcp_android-dri-s2_batch_search` | Search past incidents AND/OR TSGs in parallel | `searches`: array of `{"type": "icm"\|"tsg", "query": "..."}` |
+| `mcp_android-dri-s2_search_tsgs` | Search troubleshooting guides (single query) | `query` (required) |
+
+Use `tool_search` with query `android-dri-s` to load these tools before first use.
 
 ### Kusto
 - Delegate to the [`kusto-analyst`](../kusto-analyst/SKILL.md) skill for all KQL work — cluster/database/table identifiers, field schema, and query construction live there.

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -41,9 +41,9 @@
       "tools": ["*"]
     },
 
-    "MyDRICopilot": {
+    "android-dri-search": {
       "type": "http",
-      "url": "https://msalandroiddricopilot.azurewebsites.net/mcp"
+      "url": "https://android-dri-mcp.proudbeach-7e7ce77d.eastus.azurecontainerapps.io/mcp"
     }
   }
 }


### PR DESCRIPTION
- Update copilot-instructions.md section 1.3 with new tool table
- Migrate aria-alert-investigator skill to use batch_search
- Remove old MyDRICopilot entry from .vscode/mcp.json
- incident-investigator already migrated (no new changes)
Fixes [AB#3601970](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3601970)