### PR TITLE
Fix/update android dri mcp tool prefix, Fixes AB#3601970

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,9 +54,9 @@ The `android-dri-search` MCP server provides tools for querying past incidents, 
 
 | Tool | Purpose |
 |------|---------|
-| `mcp_android-dri-s2_get_incident` | Fetch a specific IcM incident by ID |
-| `mcp_android-dri-s2_batch_search` | Run multiple ICM and/or TSG searches in parallel |
-| `mcp_android-dri-s2_search_tsgs` | Search troubleshooting guides (single query) |
+| `mcp_android-dri-s_get_incident` | Fetch a specific IcM incident by ID |
+| `mcp_android-dri-s_batch_search` | Run multiple ICM and/or TSG searches in parallel |
+| `mcp_android-dri-s_search_tsgs` | Search troubleshooting guides (single query) |
 
 The server is configured in `.vscode/mcp.json` as `android-dri-search`. Authentication is automatic via Entra ID OAuth — you must be a member of the **Android Auth Client SDK** security group. See `android_dri_mcp_server/deployment-and-connection-guide.md` for details.
 

--- a/.github/skills/aria-alert-investigator/SKILL.md
+++ b/.github/skills/aria-alert-investigator/SKILL.md
@@ -120,7 +120,7 @@ Skip this step only if Step 1 already surfaced 3+ past ICMs in the same metric f
 Use `tool_search` with query `android-dri-s` to load the tools, then call `batch_search`:
 
 ```
-mcp_android-dri-s2_batch_search(searches=[
+mcp_android-dri-s_batch_search(searches=[
   {"type": "icm", "query": "Aria alert <metric_name> <project>"},
   {"type": "icm", "query": "Aria detected incident <metric_name> anomaly"}
 ])
@@ -200,9 +200,9 @@ Example:
 
 | Tool | Purpose | Key Parameters |
 |------|---------|-----------------|
-| `mcp_android-dri-s2_get_incident` | Fetch incident details by ID | `incident_id` (required) |
-| `mcp_android-dri-s2_batch_search` | Search past incidents AND/OR TSGs in parallel | `searches`: array of `{"type": "icm"\|"tsg", "query": "..."}` |
-| `mcp_android-dri-s2_search_tsgs` | Search troubleshooting guides (single query) | `query` (required) |
+| `mcp_android-dri-s_get_incident` | Fetch incident details by ID | `incident_id` (required) |
+| `mcp_android-dri-s_batch_search` | Search past incidents AND/OR TSGs in parallel | `searches`: array of `{"type": "icm"\|"tsg", "query": "..."}` |
+| `mcp_android-dri-s_search_tsgs` | Search troubleshooting guides (single query) | `query` (required) |
 
 Use `tool_search` with query `android-dri-s` to load these tools before first use.
 


### PR DESCRIPTION
In my previous PR, I merged the android dri mcp tool but a lot of references in the code were still pointing to older mcp tool names. In this PR, I have modified all the references.

Fixes [AB#3601970](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3601970)