### PR TITLE
Build perf: enable Gradle configure-on-demand, Fixes AB#3609347

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ android.nonFinalResIds=false
 # https://office.visualstudio.com/Outlook%20Mobile/_wiki/wikis/Outlook-Mobile.wiki/3780/Android-Studio-Gradle-Performance-tips-and-tricks
 org.gradle.parallel=true
 org.gradle.daemon=true
+org.gradle.configureondemand=true
 org.gradle.warning.mode=all
 android.defaults.buildfeatures.buildconfig=true
 


### PR DESCRIPTION
[AB#3609347](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3609347)

## Why

Test app builds (BrokerHost, msalTestApp, msalAutomationApp) and other meta-builds rooted at android-complete were spending **10-17 minutes per Gradle invocation just configuring sibling subprojects** that the requested task didn't actually depend on.

## What

Adds `org.gradle.configureondemand=true` to `gradle.properties`. When enabled, Gradle only configures projects that are in the dependency graph of the requested tasks.

## Companion changes

This matches the same flag already added to:
- common (PR for `fadi/publish-libraries-to-newandroid-feed`)
- broker (PR #172)
- msal (PR #2512)

Combined with pipeline-side changes in 1ES-Pipelines (drop `clean`, add `--build-cache --parallel`, combine multi-Gradle invocations), expected to cut test app build times by 10-15 min per stage.

## Risk

Low. configure-on-demand is a long-stable Gradle feature; we use explicit dependency declarations throughout, not implicit cross-project task wiring.