### PR TITLE
Update OpenTelemetry to 1.62.0, Fixes AB#3611236

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -74,7 +74,11 @@ ext {
     androidxAnnotationVersion = "1.4.0"
     spotBugsAnnotationVersion = "4.3.0"
     jcipAnnotationVersion = "1.0-1"
-    openTelemetryVersion = "1.18.0"
+    openTelemetryVersion = "1.62.0"
+    // Pinned to 1.18.0 because newer versions add a 'strictly' kotlin-stdlib 2.x
+    // constraint that conflicts with the project's Kotlin 1.8 compiler. Realign
+    // once the project upgrades Kotlin to 2.x.
+    openTelemetryExtensionKotlinVersion = "1.18.0"
     jetpackDataStoreVersion = "1.0.0"
     blockstoreVersion="16.2.0"
     lifecycleKtxVersion="2.5.1"


### PR DESCRIPTION
[AB#3611236](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3611236)

Updates `opentelemetry-api` (and transitives) from 1.18.0 to 1.62.0 in the composite build.

Depends on:
- common: AzureAD/microsoft-authentication-library-common-for-android#3125
- broker: identity-authnz-teams/ad-accounts-for-android#177
- authenticator: msazure/One/AD-MFA-phonefactor-phoneApp-android PR#15798277

## Changes
- `gradle/versions.gradle` -- `openTelemetryVersion` 1.18.0 -> 1.62.0; pin `opentelemetry-extension-kotlin` to 1.18.0 via a new `openTelemetryExtensionKotlinVersion` variable. Newer `extension-kotlin` releases add a `strictly` `kotlin-stdlib` 2.x constraint that conflicts with the project's Kotlin 1.8 compiler. The pin is binary-compatible -- `extension-kotlin` only calls stable `Context` APIs unchanged across 1.18 -> 1.62.

## Validation
- Composite `:common:assembleLocalDebug` -- SUCCESSFUL
- Composite `:AADAuthenticator:assembleLocalDebug` -- SUCCESSFUL
- All OTel-related unit tests pass (`EUClaimStorageUtilTest`, `ClientDataInfoTest`, `TelemetryTest` -- 27/27)
- Pre-existing `NativeAuth*Test` failures (`ApiConstants.MockApi` requires `MOCK_API_URL` system property; unrelated to this change).