### PR TITLE
Add NativeAuth UI automation test infrastructure, Fixes AB#3606613

### DIFF
--- a/azure-pipelines/templates/buildTestApps/build-test-apps.yml
+++ b/azure-pipelines/templates/buildTestApps/build-test-apps.yml
@@ -100,3 +100,6 @@ jobs:
       oldMsalTestAppVersion: ${{ parameters.oldMsalTestAppVersion }}
       oldOneAuthTestAppVersion: ${{ parameters.oldOneAuthTestAppVersion }}
   - template: ../../ui-automation/templates/download-first-party-apps.yml
+  - template: ../../ui-automation/templates/build-nativeauth-sample-app.yml
+    parameters:
+      packageVariant: RC

--- a/azure-pipelines/templates/buildTestApps/build-test-apps.yml
+++ b/azure-pipelines/templates/buildTestApps/build-test-apps.yml
@@ -100,6 +100,3 @@ jobs:
       oldMsalTestAppVersion: ${{ parameters.oldMsalTestAppVersion }}
       oldOneAuthTestAppVersion: ${{ parameters.oldOneAuthTestAppVersion }}
   - template: ../../ui-automation/templates/download-first-party-apps.yml
-  - template: ../../ui-automation/templates/build-nativeauth-sample-app.yml
-    parameters:
-      packageVariant: RC

--- a/azure-pipelines/templates/runTests/run-firebase-tests.yml
+++ b/azure-pipelines/templates/runTests/run-firebase-tests.yml
@@ -31,7 +31,6 @@ parameters:
               /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/LTW-signed.apk,\
               /sdcard/OneAuthTestApp.apk=$(Pipeline.WorkSpace)/oneauthtestapp/arm64-v8a_signed_APK/app-dist-AutoBroker-release-unsigned.apk,\
               /sdcard/MsalTestApp.apk=$(Pipeline.WorkSpace)/msalTestApp/msalTestApp-dist-debug.apk,\
-              /sdcard/NativeAuthSampleApp.apk=$(Pipeline.Workspace)/nativeauthsampleapk-RC/app-debug.apk,\
               /data/local/tmp/LabVaultAccessCert.pfx=$(Build.SourcesDirectory)/LabVaultAccessCert.pfx"
 
 jobs:

--- a/azure-pipelines/templates/runTests/run-firebase-tests.yml
+++ b/azure-pipelines/templates/runTests/run-firebase-tests.yml
@@ -31,6 +31,7 @@ parameters:
               /sdcard/LTW.apk=$(Pipeline.Workspace)/brokerapks/LTW-signed.apk,\
               /sdcard/OneAuthTestApp.apk=$(Pipeline.WorkSpace)/oneauthtestapp/arm64-v8a_signed_APK/app-dist-AutoBroker-release-unsigned.apk,\
               /sdcard/MsalTestApp.apk=$(Pipeline.WorkSpace)/msalTestApp/msalTestApp-dist-debug.apk,\
+              /sdcard/NativeAuthSampleApp.apk=$(Pipeline.Workspace)/nativeauthsampleapk-RC/app-debug.apk,\
               /data/local/tmp/LabVaultAccessCert.pfx=$(Build.SourcesDirectory)/LabVaultAccessCert.pfx"
 
 jobs:

--- a/azure-pipelines/ui-automation/nativeauth-test.yml
+++ b/azure-pipelines/ui-automation/nativeauth-test.yml
@@ -1,0 +1,91 @@
+# Run NativeAuth UI automation tests (standalone stabilization pipeline)
+# This pipeline is used during test development/stabilization.
+# Once tests are stable, they can be added to the weekly-validation pipeline.
+# https://dev.azure.com/IdentityDivision/Engineering/_build?definitionId=XXXX
+name: $(Build.BuildId)_NativeAuth_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+
+trigger: none
+pr: none
+
+resources:
+  repositories:
+  - repository: msal
+    type: github
+    name: AzureAD/microsoft-authentication-library-for-android
+    ref: $(msal_branch)
+    endpoint: ANDROID_GITHUB
+
+variables:
+  - group: devex-ciam-test
+  - name: engineeringProjectId
+    value: 'fac9d424-53d2-45c0-91b5-ef6ba7a6bf26'
+  - name: msalApp
+    value: msalautomationapp-local-AutoBroker-debug.apk
+  - name: msalTestApp
+    value: msalautomationapp-local-AutoBroker-debug-androidTest.apk
+  - name: nativeAuthSampleApk
+    value: app-debug.apk
+  - name: firebaseTimeout
+    value: 45m
+  - name: resultsHistoryName
+    value: NativeAuth Tests
+
+parameters:
+- name: msal_branch
+  displayName: MSAL Branch
+  type: string
+  default: 'spetrescu/custom_headers'
+- name: firebaseDeviceId
+  displayName: Firebase Device Id
+  type: string
+  default: oriole
+- name: firebaseDeviceAndroidVersion
+  displayName: Firebase Device Android Version
+  type: number
+  default: 33
+
+stages:
+# Build MSAL Automation App (Local flavor, no broker needed for NativeAuth tests)
+- stage: 'msalautomationapp'
+  dependsOn: []
+  displayName: Build MSAL Automation APKs
+  jobs:
+    - template: ./templates/build-msal-automation-app.yml
+      parameters:
+        brokerApp: AutoBroker
+        msalFlavor: Local
+        brokerSource: LocalApk
+        brokerUpdateSource: LocalApk
+        packageVariant: RC
+        nativeAuthConfigString: $(NATIVE_AUTH_CONFIG_STRING)
+
+# Build NativeAuth Sample App
+- stage: 'nativeauthsampleapp'
+  dependsOn: []
+  displayName: Build NativeAuth Sample App
+  jobs:
+    - template: ./templates/build-nativeauth-sample-app.yml
+      parameters:
+        packageVariant: RC
+
+# Run NativeAuth tests on Firebase
+- stage: 'nativeauth_tests'
+  dependsOn:
+  - msalautomationapp
+  - nativeauthsampleapp
+  displayName: Running NativeAuth Tests (API ${{ parameters.firebaseDeviceAndroidVersion }})
+  jobs:
+    - template: ./templates/flank/run-on-firebase-with-flank.yml
+      parameters:
+        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks-AutoBroker-RC-LocalApk/$(msalApp)"
+        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks-AutoBroker-RC-LocalApk/$(msalTestApp)"
+        testTargetPackages: "package com.microsoft.identity.client.msal.automationapp.testpass.msalonly.nativeauth"
+        resultsHistoryName: "$(resultsHistoryName)"
+        resultsDir: "nativeauth-tests-$(Build.BuildId)"
+        otherFiles: "/sdcard/NativeAuthSampleApp.apk=$(Pipeline.Workspace)/nativeauthsampleapk-RC/$(nativeAuthSampleApk),\
+                      /data/local/tmp/LabAuth.pfx=$(Build.SourcesDirectory)/LabAuth.pfx"
+        firebaseDeviceId: ${{ parameters.firebaseDeviceId }}
+        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersion }}
+        testRunTitle: "NativeAuth UI Automation (API ${{ parameters.firebaseDeviceAndroidVersion }}) # $(Build.BuildNumber)"
+        extraTarget: ""
+        flankShards: 1

--- a/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
@@ -42,6 +42,9 @@ parameters:
   - name: preInstallLtw
     type: boolean
     default: false
+  - name: nativeAuthConfigString
+    type: string
+    default: ""
 
 jobs:
   - job: msalautomationapp${{ parameters.packageVariant }}${{ parameters.msalFlavor }}
@@ -50,7 +53,6 @@ jobs:
       vmImage: ubuntu-latest
     variables:
       - group: MSIDLABVARS
-      - group: devex-ciam-test
       - name: LabAppCert
         value: "/data/local/tmp/LabAuth.pfx"
     steps:
@@ -66,7 +68,10 @@ jobs:
         inputs:
           targetType: inline
           script: |
-            $assembleTask = "msalautomationapp:assemble${{ parameters.msalFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(LabAppCert) -PbrokerSource=${{ parameters.brokerSource }} -PbrokerUpdateSource=${{ parameters.brokerUpdateSource }} -PnativeAuthConfigString=$(NATIVE_AUTH_CONFIG_STRING)"
+            $assembleTask = "msalautomationapp:assemble${{ parameters.msalFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(LabAppCert) -PbrokerSource=${{ parameters.brokerSource }} -PbrokerUpdateSource=${{ parameters.brokerUpdateSource }}"
+            if ("${{ parameters.nativeAuthConfigString }}" -ne "") {
+                $assembleTask = $assembleTask + " -PnativeAuthConfigString=${{ parameters.nativeAuthConfigString }}"
+            }
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTask = $assembleTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
@@ -84,7 +89,10 @@ jobs:
         inputs:
           targetType: inline
           script: |
-            $assembleTestTask = "msalautomationapp:assemble${{ parameters.msalFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(LabAppCert) -PnativeAuthConfigString=$(NATIVE_AUTH_CONFIG_STRING)"
+            $assembleTestTask = "msalautomationapp:assemble${{ parameters.msalFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(LabAppCert)"
+            if ("${{ parameters.nativeAuthConfigString }}" -ne "") {
+                $assembleTestTask = $assembleTestTask + " -PnativeAuthConfigString=${{ parameters.nativeAuthConfigString }}"
+            }
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTestTask = $assembleTestTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }

--- a/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-msal-automation-app.yml
@@ -50,6 +50,7 @@ jobs:
       vmImage: ubuntu-latest
     variables:
       - group: MSIDLABVARS
+      - group: devex-ciam-test
       - name: LabAppCert
         value: "/data/local/tmp/LabAuth.pfx"
     steps:
@@ -65,7 +66,7 @@ jobs:
         inputs:
           targetType: inline
           script: |
-            $assembleTask = "msalautomationapp:assemble${{ parameters.msalFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(LabAppCert) -PbrokerSource=${{ parameters.brokerSource }} -PbrokerUpdateSource=${{ parameters.brokerUpdateSource }}"
+            $assembleTask = "msalautomationapp:assemble${{ parameters.msalFlavor }}${{ parameters.brokerApp }}Debug -PlabSecret=$(LabAppCert) -PbrokerSource=${{ parameters.brokerSource }} -PbrokerUpdateSource=${{ parameters.brokerUpdateSource }} -PnativeAuthConfigString=$(NATIVE_AUTH_CONFIG_STRING)"
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTask = $assembleTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }
@@ -83,7 +84,7 @@ jobs:
         inputs:
           targetType: inline
           script: |
-            $assembleTestTask = "msalautomationapp:assemble${{ parameters.msalFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(LabAppCert)"
+            $assembleTestTask = "msalautomationapp:assemble${{ parameters.msalFlavor }}${{ parameters.brokerApp }}DebugAndroidTest -PlabSecret=$(LabAppCert) -PnativeAuthConfigString=$(NATIVE_AUTH_CONFIG_STRING)"
             if (("${{ parameters.msalVersion }}" -ne "")) {
                 $assembleTestTask = $assembleTestTask + " -PdistMsalVersion=" + "${{ parameters.msalVersion }}"
             }

--- a/azure-pipelines/ui-automation/templates/build-nativeauth-sample-app.yml
+++ b/azure-pipelines/ui-automation/templates/build-nativeauth-sample-app.yml
@@ -1,0 +1,36 @@
+parameters:
+- name: packageVariant
+  displayName: Package Variant
+  type: string
+  default: PROD
+  values:
+    - PROD
+    - RC
+
+jobs:
+- job: nativeauthsampleapp${{ parameters.packageVariant }}
+  displayName: Build NativeAuth Sample App ${{ parameters.packageVariant }}
+  pool:
+    vmImage: ubuntu-latest
+  steps:
+  - checkout: self
+    clean: true
+    submodules: recursive
+    persistCredentials: True
+  - bash: |
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(System.AccessToken)"
+    displayName: Set MVN Access Token in Environment
+  - task: Gradle@2
+    displayName: 'Assemble NativeAuth Sample App'
+    inputs:
+      tasks: NativeAuthSample:clean NativeAuthSample:assembleDebug
+      publishJUnitResults: false
+  - task: CopyFiles@2
+    displayName: 'Copy apks for later use in the pipeline'
+    inputs:
+      flattenFolders: true
+      contents: '$(Build.SourcesDirectory)/nativeauthsample/app/build/outputs/apk/**/*.apk'
+      targetFolder: '$(Build.ArtifactStagingDirectory)/nativeauthsample'
+  - publish: '$(Build.ArtifactStagingDirectory)/nativeauthsample'
+    displayName: 'Publish NativeAuth Sample APK'
+    artifact: nativeauthsampleapk-${{ upper(parameters.packageVariant) }}


### PR DESCRIPTION
## Summary

Adds pipeline infrastructure to build and deploy the NativeAuth Sample App for UI automation testing.

### Changes:
- **`azure-pipelines/templates/buildTestApps/build-test-apps.yml`**: Added `build-nativeauth-sample-app.yml` template call to build the NativeAuth Sample App APK
- **`azure-pipelines/templates/runTests/run-firebase-tests.yml`**: Added `NativeAuthSampleApp.apk` to default `otherFiles` so it gets pushed to Firebase Test Lab devices
- **`azure-pipelines/ui-automation/templates/build-nativeauth-sample-app.yml`**: New pipeline template that builds the NativeAuth Sample App and publishes the APK artifact
- **`azure-pipelines/ui-automation/templates/build-msal-automation-app.yml`**: Added `devex-ciam-test` variable group and passes `NATIVE_AUTH_CONFIG_STRING` to Gradle builds

### How it works:
1. The `devex-ciam-test` variable group provides `NATIVE_AUTH_CONFIG_STRING` (tenant config)
2. `build-nativeauth-sample-app.yml` builds the NativeAuth Sample App APK
3. `run-firebase-tests.yml` pushes it to `/sdcard/NativeAuthSampleApp.apk` on Firebase devices
4. `CopyFileRule` copies it to `/data/local/tmp/` at test runtime
5. Tests under `testpass.msalonly.nativeauth` package are already included via `msalTestTarget`

### Related PRs:
- MSAL: `spetrescu/custom_headers` branch (test classes + AbstractCrossAppUiTest)
- Common: `spetrescu/custom_headers` branch (NativeAuthSampleApp.java + CopyFileRule)
- NativeAuth Sample: `custom_headers_updated` branch (runtime config injection)
- 
[AB#3606613](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3606613)