### PR TITLE
Harden OCE report skill against dim-pct name-column starvation, Fixes AB#3678009

### DIFF
--- a/.github/skills/oncall-weekly-telemetry-report/assets/scripts/validate-report.ps1
+++ b/.github/skills/oncall-weekly-telemetry-report/assets/scripts/validate-report.ps1
@@ -21,6 +21,9 @@
                on .dim-name / .dim-row > span:first-of-type AND min-width:0 on
                .dim / .dim-row so long calling-app / version names truncate inside
                their dim card rather than bleeding out.
+           9c. .dim-pct content guard — every dim-pct cell must be a short bare
+               percentage (no "(...)" annotations, <= 9 chars). A long pct value
+               starves the flex name column and collapses real labels to "1...".
 
     Exits with non-zero status if any HARD check fails (stale tokens, devs/reqs leak,
     U+FFFD, unbalanced div depth, missing layout-guard CSS).
@@ -259,6 +262,24 @@ if ($hasAttrCard) {
         Add-Warn "CSS has text-overflow rules but is missing min-width:0 on .dim / .dim-row. Without it, flex children won't shrink below content size and ellipsis won't trigger inside narrow dim cards."
     } else {
         Pass "Dim-row name-overflow guard CSS present (ellipsis + min-width:0)"
+    }
+}
+
+# 9c. Dim-pct content guard (CONTENT, not CSS): the percent cell must be a short
+#     bare percentage (e.g. "50.7%", "100%", "+759%"). A long value such as
+#     "75% (+111%)" sits in the narrow, fixed pct column and starves the flex
+#     name column, collapsing real labels to a couple of chars ("16.1.0" -> "1...").
+#     9b only proves the CSS guard exists; this catches the authoring mistake that
+#     slips past it. WoW deltas belong in card prose / tags, never in dim-pct.
+if ($hasAttrCard) {
+    $badPct = [regex]::Matches($content, '<span class="dim-pct">([^<]*)</span>') |
+        ForEach-Object { $_.Groups[1].Value.Trim() } |
+        Where-Object { $_ -match '\(' -or $_.Length -gt 9 }
+    if ($badPct.Count -gt 0) {
+        $sample = (($badPct | Select-Object -Unique -First 5) -join '  |  ')
+        Add-Fail "dim-pct cells must be a short bare percentage (e.g. '50.7%'). Found $($badPct.Count) overlong/annotated value(s) that starve the name column and truncate labels: $sample . Move WoW deltas into the card prose / tags, not the pct cell."
+    } else {
+        Pass "dim-pct cells are short bare percentages (name column protected)"
     }
 }
 

--- a/.github/skills/oncall-weekly-telemetry-report/assets/templates/report-template.html
+++ b/.github/skills/oncall-weekly-telemetry-report/assets/templates/report-template.html
@@ -210,12 +210,18 @@
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
     font-family: "SF Mono", Consolas, monospace; font-size: 11.5px; color: #0d1117;
   }
-  /* Percent column — classed (.dim-pct) OR last unclassed <span> */
+  /* Percent column — classed (.dim-pct) OR last unclassed <span>.
+     MUST be a short bare percentage (e.g. "50.7%"). flex-shrink:1 + a hard
+     max-width cap guarantee that even if an author wrongly stuffs a long value
+     (e.g. "75% (+111%)") into this cell it truncates ITSELF instead of starving
+     the flex name column and collapsing real labels to "1...". The validator
+     (check 9c) additionally fails the build on overlong/annotated pct cells. */
   .dim-row .dim-pct,
   .dim-row > span:last-of-type {
-    flex: 0 0 auto;
+    flex: 0 1 auto;
     font-variant-numeric: tabular-nums; color: #656d76; font-size: 11px;
-    min-width: 38px; text-align: right; white-space: nowrap;
+    min-width: 38px; max-width: 72px; overflow: hidden; text-overflow: ellipsis;
+    text-align: right; white-space: nowrap;
   }
   /* Single-span placeholder rows (e.g. "Not sliced — …") — allow wrap, not truncate.
      Long inline <code> blocks should wrap inside the cell rather than expanding

--- a/.github/skills/oncall-weekly-telemetry-report/assets/templates/spike-card.html
+++ b/.github/skills/oncall-weekly-telemetry-report/assets/templates/spike-card.html
@@ -63,9 +63,17 @@
              <span style="color:#656d76;font-size:11.5px;">Not sliced — OEM not suspected.</span>
            </div>
 
-         Long names (calling apps, broker versions with annotations) MUST truncate
-         to an ellipsis — never wrap, never bleed out of the .dim card. The CSS
-         in assets/templates/report-template.html handles this for both variants. -->
+         Long NAMES (calling apps, broker versions) MUST truncate to an ellipsis —
+         never wrap, never bleed out of the .dim card. The CSS in
+         assets/templates/report-template.html handles this for both variants.
+
+         dim-pct RULE (do not violate): the percent cell is a SHORT bare percentage
+         only — "36.6%", "100%", "+759%". NEVER put WoW deltas or annotations like
+         "50.7% (+646%)" or "75% (+111%)" in the pct cell. The pct column is narrow;
+         a long value starves the flex name column and collapses real labels to a
+         couple of characters ("16.1.0" -> "1..."). Put per-slice movement in the
+         card prose / tags / Caller hot-spots instead. The validator fails (9c) on
+         any dim-pct that contains "(" or exceeds 9 characters. -->
     <div class="attr-dims">
       <div class="dim"><div class="dim-label">Span</div>
         {{SPAN_DIM_ROWS}}


### PR DESCRIPTION
## Summary

In the **oncall-weekly-telemetry-report** skill, a Spike Attribution `dim-pct` cell that carried a WoW annotation (e.g. `75% (+111%)`) sat in the narrow, fixed percent column and **starved the flex name column**, collapsing real labels to a couple of characters — broker version `16.1.0` rendered as `1...`, `KeyPairGeneration` as `KeyPai...`. The existing layout guards (checks 9a/9b) only assert the CSS exists; they couldn''t catch this content-level authoring mistake.

This adds a three-layer defense so it can''t recur.

## Changes

1. **CSS — self-defense** (`assets/templates/report-template.html`): `.dim-pct` changed from `flex: 0 0 auto` to `flex: 0 1 auto` with `max-width: 72px` + `overflow:hidden; text-overflow:ellipsis`. A stray long value now truncates itself instead of the name.
2. **Validator — hard fail** (`assets/scripts/validate-report.ps1`): new **check 9c** fails the build if any `dim-pct` cell contains `(` or exceeds 9 characters. Also listed in the validator header doc.
3. **Author guidance** (`assets/templates/spike-card.html`): documents that `dim-pct` is a short bare percentage only; WoW deltas go in prose / tags / Caller hot-spots.

## Validation
- `validate-report.ps1` passes all hard checks, including the new `[OK] dim-pct cells are short bare percentages`.
- Negative test confirms `75% (+111%)` is flagged while `50.7%`, `+759%`, `100.0%` pass clean.
- `visual-smoke.ps1`: 0 overflow / 0 adjacent-gap issues.

No functional report content changed — skill-hardening only.

Work item: [AB#3678009](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3678009)
