### PR TITLE
Add Android DRI Search MCP to agency.toml, Fixes AB#3684589

### DIFF
--- a/agency.toml
+++ b/agency.toml
@@ -7,6 +7,10 @@ es-chat        = { type = "es-chat" }
 workiq         = { type = "workiq" }
 m365-user      = { type = "m365-user" }
 s360-breeze    = { type = "s360-breeze" }
+# Kusto — android_spans / android_metrics telemetry + eSTS correlation (used by incident/aria investigator + kusto-analyst skills).
+kusto          = { type = "kusto" }
+# ICM — read/triage IcM tickets (used by incident-investigator + aria-alert-investigator skills).
+icm            = { type = "icm" }
 
 [mcps.servers]
 # Android DRI Search — MSAL/Broker/Authenticator TSGs + past ICM incidents via Azure AI Search.

--- a/agency.toml
+++ b/agency.toml
@@ -7,3 +7,8 @@ es-chat        = { type = "es-chat" }
 workiq         = { type = "workiq" }
 m365-user      = { type = "m365-user" }
 s360-breeze    = { type = "s360-breeze" }
+
+[mcps.servers]
+# Android DRI Search — MSAL/Broker/Authenticator TSGs + past ICM incidents via Azure AI Search.
+# Custom remote MCP (Entra-authenticated); Agency handles the auth/proxy automatically.
+android-dri-search = { type = "http", url = "https://android-dri-mcp.proudbeach-7e7ce77d.eastus.azurecontainerapps.io/mcp", tools = ["*"] }


### PR DESCRIPTION
## What

Adds the **Android DRI Search** MCP and a couple more to the repo-level `agency.toml` under `[mcps.servers]`.

## Why

Registering it here means anyone who runs Agency (`agency copilot` / `agency claude`) from this repo automatically gets the Android Auth DRI tools — no per-person config. The server exposes MSAL / Broker / Authenticator troubleshooting guides and past ICM incidents via Azure AI Search.

Tools exposed: `search_tsgs`, `get_incident`, `batch_search`, `post_icm_discussion`.

## Notes

- It's a custom **remote** MCP (not an Agency built-in), so it goes under `[mcps.servers]` rather than `[mcps.builtins]`.
- Auth is Microsoft Entra ID; Agency handles the token/proxy automatically. Access is restricted to the **Android Auth Client SDK** security group.
- Usage TSG: How to use the Android DRI Search MCP in Agency.


Fixes [AB#3684589](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3684589)