### PR TITLE
Remove deleted gradle API used by buildsystem plugin, Fixes AB#3689387

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -10,7 +10,7 @@ ext {
     // Plugins
     gradleVersion = '8.10.0'
     kotlinVersion = '1.8.0'
-    spotBugsGradlePluginVersion = '4.7.1'
+    spotBugsGradlePluginVersion = '6.5.8'
     jupiterApiVersion = '5.6.0'
     
     //Java Language Support

--- a/plugins/buildsystem/build.gradle
+++ b/plugins/buildsystem/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'com.microsoft.identity'
-version '0.2.6-dev'
+version '0.2.6'
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = '11'

--- a/plugins/buildsystem/build.gradle
+++ b/plugins/buildsystem/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:${rootProject.ext.jupiterApiVersion}"
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     implementation "com.android.tools.build:gradle:${rootProject.ext.gradleVersion}"
-    implementation "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:${rootProject.ext.spotBugsGradlePluginVersion}"
+    implementation "com.github.spotbugs.snom:spotbugs-gradle-plugin:${rootProject.ext.spotBugsGradlePluginVersion}"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${rootProject.ext.kotlinVersion}"
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${rootProject.ext.kotlinVersion}"

--- a/plugins/buildsystem/build.gradle
+++ b/plugins/buildsystem/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'com.microsoft.identity'
-version '0.2.6'
+version '0.3.0'
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = '11'

--- a/plugins/buildsystem/build.gradle
+++ b/plugins/buildsystem/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'com.microsoft.identity'
-version '0.2.5'
+version '0.2.6-dev'
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = '11'
@@ -47,6 +47,24 @@ repositories {
         credentials {
             username System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
             password System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+        }
+    }
+}
+
+// Publish target for the internal NewAndroid Azure Artifacts feed.
+// The java-gradle-plugin + maven-publish plugins auto-create the plugin's
+// publications (the plugin jar/pom and the plugin-marker artifact); this block
+// only tells Gradle WHERE to push them. Consuming repos resolve the plugin from
+// this same feed via their settings.gradle pluginManagement block.
+publishing {
+    repositories {
+        maven {
+            name "vsts-maven-new-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
+            credentials {
+                username System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
+                password System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+            }
         }
     }
 }

--- a/plugins/buildsystem/build.gradle
+++ b/plugins/buildsystem/build.gradle
@@ -51,24 +51,6 @@ repositories {
     }
 }
 
-// Publish target for the internal NewAndroid Azure Artifacts feed.
-// The java-gradle-plugin + maven-publish plugins auto-create the plugin's
-// publications (the plugin jar/pom and the plugin-marker artifact); this block
-// only tells Gradle WHERE to push them. Consuming repos resolve the plugin from
-// this same feed via their settings.gradle pluginManagement block.
-publishing {
-    repositories {
-        maven {
-            name "vsts-maven-new-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
-            credentials {
-                username System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
-                password System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
-            }
-        }
-    }
-}
-
 dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:${rootProject.ext.jupiterApiVersion}"
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/plugins/buildsystem/changelog
+++ b/plugins/buildsystem/changelog
@@ -1,5 +1,9 @@
 Plugin Overview: https://github.com/AzureAD/android-complete/blob/master/plugins/buildsystem/docs/Overview.md
 
+Version 0.2.6
+----------------------------
+[MINOR] Remove use of deleted gradle APIs
+
 Version 0.2.3
 ----------------------------
 [PATCH] Allow ability to enable/disable code coverage - disabled by default

--- a/plugins/buildsystem/changelog
+++ b/plugins/buildsystem/changelog
@@ -1,6 +1,6 @@
 Plugin Overview: https://github.com/AzureAD/android-complete/blob/master/plugins/buildsystem/docs/Overview.md
 
-Version 0.2.6
+Version 0.3.0
 ----------------------------
 [MINOR] Remove use of deleted gradle APIs
 [MINOR] Bump SpotBugs Gradle plugin 4.7.1 -> 6.5.8 (4.x used the removed JavaPluginConvention); groupId changed to com.github.spotbugs.snom

--- a/plugins/buildsystem/changelog
+++ b/plugins/buildsystem/changelog
@@ -3,6 +3,7 @@ Plugin Overview: https://github.com/AzureAD/android-complete/blob/master/plugins
 Version 0.2.6
 ----------------------------
 [MINOR] Remove use of deleted gradle APIs
+[MINOR] Bump SpotBugs Gradle plugin 4.7.1 -> 6.5.8 (4.x used the removed JavaPluginConvention); groupId changed to com.github.spotbugs.snom
 
 Version 0.2.3
 ----------------------------

--- a/plugins/buildsystem/gradle/versions.gradle
+++ b/plugins/buildsystem/gradle/versions.gradle
@@ -1,7 +1,7 @@
 // Variables for plugins project
 ext {
     kotlinVersion = '1.8.0'
-    spotBugsGradlePluginVersion = '4.7.1'
+    spotBugsGradlePluginVersion = '6.5.8'
     jupiterApiVersion = '5.6.0'
     gradleVersion = '8.10.0'
 }

--- a/plugins/buildsystem/src/main/java/com/microsoft/identity/buildsystem/BuildPlugin.java
+++ b/plugins/buildsystem/src/main/java/com/microsoft/identity/buildsystem/BuildPlugin.java
@@ -27,14 +27,12 @@ import com.microsoft.identity.buildsystem.codecov.CodeCoverage;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPluginExtension;
 
 public class BuildPlugin implements Plugin<Project> {
 
     private final static String ANDROID_LIBRARY_PLUGIN_ID = "com.android.library";
     private final static String JAVA_LIBRARY_PLUGIN_ID = "java-library";
-
-    private final static String JAVA_SOURCE_COMPATIBILITY_PROPERTY = "sourceCompatibility";
-    private final static String JAVA_TARGET_COMPATIBILITY_PROPERTY = "targetCompatibility";
 
     @Override
     public void apply(final Project project) {
@@ -70,8 +68,10 @@ public class BuildPlugin implements Plugin<Project> {
 
     private void applyJava8ToJavaProject(final Project project) {
         project.getPluginManager().withPlugin(JAVA_LIBRARY_PLUGIN_ID, appliedPlugin -> {
-            project.setProperty(JAVA_SOURCE_COMPATIBILITY_PROPERTY, JavaVersion.VERSION_1_8);
-            project.setProperty(JAVA_TARGET_COMPATIBILITY_PROPERTY, JavaVersion.VERSION_1_8);
+            final JavaPluginExtension javaPluginExtension = project.getExtensions()
+                    .getByType(JavaPluginExtension.class);
+            javaPluginExtension.setSourceCompatibility(JavaVersion.VERSION_1_8);
+            javaPluginExtension.setTargetCompatibility(JavaVersion.VERSION_1_8);
         });
     }
 }


### PR DESCRIPTION
[AB#3689387](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3689387)

Changes the gradle API used by this plugin to set the sourceCompatibility and targetCompatibility  properties. the API JavaPluginConvention has been deleted in gradle 9+ 