### PR TITLE
Remove ADAL service tree from S360 Reporter skill, Fixes AB#3697739

### DIFF
--- a/.github/skills/s360-reporter/SKILL.md
+++ b/.github/skills/s360-reporter/SKILL.md
@@ -42,7 +42,6 @@ Skip PBI creation, report generation, and email drafting in quick mode.
 
 | Service | Service Tree ID |
 |---------|----------------|
-| AuthN SDK - ADAL Android | `937cdc57-1253-4b55-878e-5854368926a2` |
 | AuthN SDK - MSAL Android | `8d0d308e-cd5c-44a3-9518-43eeeb424b57` |
 | Microsoft Authenticator - Android | `0b97f26e-fcfc-4ed1-95e9-1dca3a2fde3b` |
 
@@ -128,13 +127,12 @@ Fetch items from **two sources** and merge them:
 
 #### 1a: Service-targeted items
 
-Call `mcp_s360-breeze-m_search_active_s360_kpi_action_items` with all three service tree IDs:
+Call `mcp_s360-breeze-m_search_active_s360_kpi_action_items` with both service tree IDs:
 
 ```
 request: {
   "pageSize": 50,
   "targetIds": [
-    "937cdc57-1253-4b55-878e-5854368926a2",
     "8d0d308e-cd5c-44a3-9518-43eeeb424b57",
     "0b97f26e-fcfc-4ed1-95e9-1dca3a2fde3b"
   ]
@@ -162,8 +160,8 @@ that are tied to individuals rather than service tree IDs.
 including items from other team memberships. After fetching, filter results to only include
 items where one of these conditions is met:
 - `TargetType` is `"Person"` AND `TargetId` exactly matches one of the team aliases
-- `TargetId` matches one of our three service tree IDs
-- `CustomDimensions.TenantName` contains "Auth Client", "MSAL", "ADAL", or "Authenticator"
+- `TargetId` matches one of our two service tree IDs
+- `CustomDimensions.TenantName` contains "Auth Client", "MSAL", or "Authenticator"
 
 **Critical — do NOT expand group items**: Each S360 item has exactly one `AssignedTo`
 and one `TargetId`. Treat each item as-is — one row per `KpiActionItemId`. Never split
@@ -200,7 +198,7 @@ inputs.
 
 **Filter logic** (enforced by the script — do not duplicate ad-hoc):
 - `TargetType == "Person"` AND `TargetId` is a team alias  → keep
-- `TargetId` is one of the three service tree GUIDs        → keep
+- `TargetId` is one of the two service tree GUIDs         → keep
 - `CustomDimensions.TenantName` matches an Auth-team pattern → keep
 - **`AssignedTo` alone is NOT sufficient** — the person query already filters by
   `assignedTo`, so every returned item has a team-alias `AssignedTo` but many are

--- a/.github/skills/s360-reporter/generate-report.js
+++ b/.github/skills/s360-reporter/generate-report.js
@@ -172,7 +172,7 @@ html += `<!DOCTYPE html>
       </tr>
     </table>
     <p style="margin:16px 0 0 0; font-size:13px;">
-      Services: <strong>AuthN SDK - MSAL Android</strong> &bull; <strong>AuthN SDK - ADAL Android</strong> &bull; <strong>Microsoft Authenticator - Android</strong>
+      Services: <strong>AuthN SDK - MSAL Android</strong> &bull; <strong>Microsoft Authenticator - Android</strong>
     </p>
   </td>
 </tr>`;

--- a/.github/skills/s360-reporter/merge-items.js
+++ b/.github/skills/s360-reporter/merge-items.js
@@ -18,7 +18,7 @@
 //
 // Inputs:
 //   --service  Raw response from search_active_s360_kpi_action_items keyed by
-//              targetIds (the 3 Android Auth service tree GUIDs).
+//              targetIds (the 2 Android Auth service tree GUIDs).
 //   --person   Raw response from the same tool keyed by assignedTo (team
 //              aliases).
 //   --team     JSON file: { aliases, nameMap, serviceIds?, tenantPatterns? }.
@@ -42,11 +42,10 @@ const path = require('path');
 
 // ── Defaults ──────────────────────────────────────────────────────────────────
 const DEFAULT_SERVICE_IDS = [
-  '937cdc57-1253-4b55-878e-5854368926a2', // AuthN SDK - ADAL Android
   '8d0d308e-cd5c-44a3-9518-43eeeb424b57', // AuthN SDK - MSAL Android
   '0b97f26e-fcfc-4ed1-95e9-1dca3a2fde3b'  // Microsoft Authenticator - Android
 ];
-const DEFAULT_TENANT_PATTERNS = ['auth client', 'msal', 'adal', 'authenticator'];
+const DEFAULT_TENANT_PATTERNS = ['auth client', 'msal', 'authenticator'];
 
 // ── CLI args ──────────────────────────────────────────────────────────────────
 function getArg(name) {

--- a/.github/skills/s360-reporter/report-template.md
+++ b/.github/skills/s360-reporter/report-template.md
@@ -94,7 +94,7 @@ Blue top bar + uppercase label + team name + blue date pill + services line.
       </tr>
     </table>
     <p style="margin:16px 0 0 0; font-size:13px;">
-      Services: <strong>AuthN SDK - MSAL Android</strong> &bull; <strong>AuthN SDK - ADAL Android</strong> &bull; <strong>Microsoft Authenticator - Android</strong>
+      Services: <strong>AuthN SDK - MSAL Android</strong> &bull; <strong>Microsoft Authenticator - Android</strong>
     </p>
   </td>
 </tr>


### PR DESCRIPTION
## Summary

We no longer monitor the **AuthN SDK - ADAL Android** service tree (`937cdc57-1253-4b55-878e-5854368926a2`), so this removes it from the `s360-reporter` skill.

## Changes

- **merge-items.js** — dropped the ADAL GUID from `DEFAULT_SERVICE_IDS`, removed `'adal'` from `DEFAULT_TENANT_PATTERNS`, and updated the "3 → 2 Android Auth service tree GUIDs" comment.
- **SKILL.md** — removed the ADAL row from the Target Services table, dropped the ADAL GUID from the `targetIds` query example, and updated the "three services / three service tree GUIDs" wording and tenant-name pattern list.
- **generate-report.js** & **report-template.md** — removed the ADAL Android chip from the report header services line.

The skill now monitors only **MSAL Android** and **Microsoft Authenticator - Android**.

Fixes [AB#3697739](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3697739)