### PR TITLE
Migrate broker references to GitHub Enterprise (msft.ghe.com), Fixes AB#3699280

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -30,7 +30,7 @@
 		git clone -b dev https://github.com/AzureAD/microsoft-authentication-library-for-android.git msal; \
 		git clone -b dev https://github.com/AzureAD/microsoft-authentication-library-common-for-android.git common; \
 		git clone -b dev https://github.com/AzureAD/azure-activedirectory-library-for-android.git adal; \
-		git clone -b dev https://github.com/identity-authnz-teams/ad-accounts-for-android.git broker; \
+		git clone -b dev https://msft.ghe.com/security/ad-accounts-for-android.git broker; \
         git clone -b master https://github.com/Azure-Samples/ms-identity-android-java.git azuresample; \
         git clone -b main https://github.com/Azure-Samples/ms-identity-ciam-native-auth-android-sample.git nativeauthsample; \
         git clone -b dev https://office.visualstudio.com/DefaultCollection/OneAuth/_git/OneAuth oneauth; \

--- a/.github/agents/agent-dispatcher.agent.md
+++ b/.github/agents/agent-dispatcher.agent.md
@@ -20,9 +20,9 @@ Read the skill file at `.github/skills/pbi-dispatcher/SKILL.md` and follow its w
    - Fall back to prompting the developer
    - **Never hardcode GitHub usernames**
 
-2. **Switch gh account** before any GitHub operations using the discovered usernames:
-   - `AzureAD/*` repos → `gh auth switch --user <discovered_public_username>`
-   - `identity-authnz-teams/*` repos → `gh auth switch --user <discovered_emu_username>`
+2. **Select the right gh host/account** before any GitHub operations using the discovered usernames:
+   - `AzureAD/*` repos (github.com) → `gh auth switch --hostname github.com --user <discovered_public_username>`
+   - `security/*` repos on `msft.ghe.com` (broker) → pass `--hostname msft.ghe.com` to every `gh` call (separate host, not an account switch)
 
 2. **Read the full PBI** from ADO using `mcp_ado_wit_get_work_item` before dispatching
 

--- a/.github/agents/feature-orchestrator.agent.md
+++ b/.github/agents/feature-orchestrator.agent.md
@@ -302,7 +302,7 @@ gh pr view <prNumber> --repo "<full-repo-slug>" --json state,title,url,statusChe
 Repo slug mapping:
 - `common` → `AzureAD/microsoft-authentication-library-common-for-android`
 - `msal` → `AzureAD/microsoft-authentication-library-for-android`
-- `broker` → `identity-authnz-teams/ad-accounts-for-android`
+- `broker` → `security/ad-accounts-for-android`
 - `adal` → `AzureAD/azure-activedirectory-library-for-android`
 
 **Step 3: Present results** as a table with: PR #, repo, title, status, checks, +/- lines.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -166,7 +166,7 @@ The `design-docs/` folder contains the `AuthLibrariesApiReview` ADO repo (cloned
 |--------|-------------|
 | common / common4j | `AzureAD/microsoft-authentication-library-common-for-android` |
 | msal | `AzureAD/microsoft-authentication-library-for-android` |
-| broker / broker4j | `identity-authnz-teams/ad-accounts-for-android` (GHE) |
+| broker / broker4j | `security/ad-accounts-for-android` (GHE) |
 | adal | `AzureAD/azure-activedirectory-library-for-android` |
 | 1ES-Pipelines | `IdentityDivision/Engineering/_git/AuthClientAndroidPipelines` (ADO) |
 

--- a/.github/prompts/broker-ghe-migrate.prompt.md
+++ b/.github/prompts/broker-ghe-migrate.prompt.md
@@ -1,0 +1,64 @@
+---
+description: "Repoint the broker repo to GitHub Enterprise (msft.ghe.com) and update local-only config"
+---
+
+# Broker → GitHub Enterprise: local setup
+
+The broker repo moved from `github.com/identity-authnz-teams/ad-accounts-for-android`
+to `msft.ghe.com/security/ad-accounts-for-android`.
+
+**Important:** the tracked files (pipeline `repository:` resources, `gh`/`curl`/API
+paths, and references) are **already updated** on `dev` in `android-complete`,
+`broker`, and `common` — a `git pull` brings them in. Do **NOT** hand-edit those
+files. Your job is only the things git can't sync: **auth**, the broker clone's
+**remote URL**, and my **per-developer config**. Leave `common` / `msal` / `adal` /
+`android-complete` remotes on github.com.
+
+Work in this order and show me a summary before any `git push`.
+
+## Step 1 — Authenticate to the new host (one-time)
+
+GHE auth is needed before broker can fetch:
+```powershell
+gh auth status --hostname msft.ghe.com
+# if not logged in:
+gh auth login --hostname msft.ghe.com --git-protocol https --web
+```
+If auth/fetch later fails with 403/404, I likely need repo access first — request the
+`security/ad-accounts-for-android` access package in My Access:
+https://myaccess.microsoft.com/@msesmecloud.onmicrosoft.com#/access-packages/0cf20674-39ff-406b-a447-e31b1923f985
+
+## Step 2 — Repoint the broker git remote (local clone config, not in source)
+
+```powershell
+git -C broker remote -v   # check current origin
+# if origin still points at github.com/identity-authnz-teams/ad-accounts-for-android:
+git -C broker remote set-url origin https://msft.ghe.com/security/ad-accounts-for-android.git
+```
+Leave `common` / `msal` / `adal` / `android-complete` remotes unchanged.
+
+## Step 3 — Pull latest (this is what updates all tracked references/YAML)
+
+```powershell
+git -C . pull          # android-complete
+git -C broker pull     # now resolves via msft.ghe.com
+git -C common pull
+```
+After this the migrated pipeline resources and `gh`/`curl` paths are present locally.
+Do NOT edit those files by hand — they came from the pull.
+
+## Step 4 — Update `.github/developer-local.json` (per-developer, gitignored)
+
+Change the account key from the old org to the new host, using MY GHE username
+(from `gh auth status --hostname msft.ghe.com`):
+```json
+{ "github_accounts": { "AzureAD": "<github_user>", "msft.ghe.com": "<ghe_user>" } }
+```
+
+## Step 5 — Validate & report
+
+1. `git -C broker remote -v` shows `msft.ghe.com/security/ad-accounts-for-android`.
+2. `git -C broker fetch origin dev` succeeds.
+3. `.github/developer-local.json` has the `msft.ghe.com` key (no `identity-authnz-teams`).
+4. Print a short table of what changed (remote URL, `developer-local.json` only).
+   Do NOT modify tracked pipeline/script files, historical `changes.txt`, or PR/commit links.

--- a/.github/prompts/feature-pr-iterate.prompt.md
+++ b/.github/prompts/feature-pr-iterate.prompt.md
@@ -44,7 +44,7 @@ This gives you:
 Repo slug mapping:
 - `common` → `AzureAD/microsoft-authentication-library-common-for-android`
 - `msal` → `AzureAD/microsoft-authentication-library-for-android`
-- `broker` → `identity-authnz-teams/ad-accounts-for-android`
+- `broker` → `security/ad-accounts-for-android`
 - `adal` → `AzureAD/azure-activedirectory-library-for-android`
 
 Discover the GitHub username from `.github/developer-local.json`, or `gh auth status`.

--- a/.github/prompts/feature-status.prompt.md
+++ b/.github/prompts/feature-status.prompt.md
@@ -25,7 +25,7 @@ gh pr view <prNumber> --repo "<full-repo-slug>" --json state,title,url,statusChe
 Repo slug mapping:
 - `common` → `AzureAD/microsoft-authentication-library-common-for-android`
 - `msal` → `AzureAD/microsoft-authentication-library-for-android`
-- `broker` → `identity-authnz-teams/ad-accounts-for-android`
+- `broker` → `security/ad-accounts-for-android`
 - `adal` → `AzureAD/azure-activedirectory-library-for-android`
 
 Discover the GitHub username from `.github/developer-local.json`, or `gh auth status`, or prompt.

--- a/.github/skills/copilot-review-analyst/SKILL.md
+++ b/.github/skills/copilot-review-analyst/SKILL.md
@@ -21,7 +21,7 @@ Default repos (update in scripts if changed):
 |-------|------|------|
 | common | `AzureAD/microsoft-authentication-library-common-for-android` | EMU (also accessible via personal) |
 | msal | `AzureAD/microsoft-authentication-library-for-android` | EMU (also accessible via personal) |
-| broker | `identity-authnz-teams/ad-accounts-for-android` | EMU only |
+| broker | `security/ad-accounts-for-android` | EMU only |
 
 ## Analysis Pipeline
 

--- a/.github/skills/copilot-review-analyst/scripts/analyze.ps1
+++ b/.github/skills/copilot-review-analyst/scripts/analyze.ps1
@@ -15,33 +15,21 @@ $ErrorActionPreference = "Continue"
 New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
 
 # ========================================
-# AUTH: Switch to EMU account (has access to all repos including private broker)
-# EMU accounts follow the *_microsoft naming convention.
+# AUTH: common/msal live on github.com; broker lives on msft.ghe.com.
+# Both hosts must be authenticated — gh routes per-host, so no account switching.
 # ========================================
-$originalAccount = gh api user --jq '.login' 2>$null
+$originalAccount = $null
 
-# Find the EMU account from gh auth status output
-$emuAccount = (gh auth status 2>&1 | Select-String 'Logged in to github.com account (\S+_microsoft)' | 
-    ForEach-Object { $_.Matches[0].Groups[1].Value } | Select-Object -First 1)
-
-if (-not $emuAccount) {
-    Write-Host "ERROR: No EMU account (*_microsoft) found in 'gh auth status'." -ForegroundColor Red
-    Write-Host "  Run: gh auth login  (and authenticate with your EMU account)" -ForegroundColor Yellow
+if (-not (gh auth status --hostname github.com 2>&1 | Select-String 'Logged in')) {
+    Write-Host "ERROR: not logged in to github.com." -ForegroundColor Red
+    Write-Host "  Run: gh auth login --hostname github.com" -ForegroundColor Yellow
     exit 1
 }
 
-if ($originalAccount -ne $emuAccount) {
-    Write-Host "Switching from '$originalAccount' to EMU account '$emuAccount'..." -ForegroundColor Cyan
-    gh auth switch --user $emuAccount 2>&1 | Out-Null
-    $currentAccount = gh api user --jq '.login' 2>$null
-    if ($currentAccount -ne $emuAccount) {
-        Write-Host "ERROR: Failed to switch to EMU account '$emuAccount'." -ForegroundColor Red
-        exit 1
-    }
-    Write-Host "  Switched to '$emuAccount'. Will restore '$originalAccount' on completion." -ForegroundColor Green
-} else {
-    Write-Host "Already using EMU account '$emuAccount'." -ForegroundColor Green
-    $originalAccount = $null  # no restore needed
+if (-not (gh auth status --hostname msft.ghe.com 2>&1 | Select-String 'Logged in')) {
+    Write-Host "ERROR: not logged in to msft.ghe.com (required for the broker repo)." -ForegroundColor Red
+    Write-Host "  Run: gh auth login --hostname msft.ghe.com" -ForegroundColor Yellow
+    exit 1
 }
 
 # Copilot uses "Copilot" for inline review comments
@@ -49,9 +37,9 @@ $COPILOT_USERS = @("Copilot", "copilot-pull-request-reviewer[bot]")
 $BOT_AUTHORS = @("app/copilot-swe-agent", "Copilot", "dependabot[bot]", "github-actions[bot]")
 
 $repos = @(
-    @{ Label = "common"; Slug = "AzureAD/microsoft-authentication-library-common-for-android" },
-    @{ Label = "msal";   Slug = "AzureAD/microsoft-authentication-library-for-android" },
-    @{ Label = "broker"; Slug = "identity-authnz-teams/ad-accounts-for-android" }
+    @{ Label = "common"; Slug = "AzureAD/microsoft-authentication-library-common-for-android"; PrRepo = "AzureAD/microsoft-authentication-library-common-for-android"; ApiRepo = "https://api.github.com/repos/AzureAD/microsoft-authentication-library-common-for-android" },
+    @{ Label = "msal";   Slug = "AzureAD/microsoft-authentication-library-for-android";        PrRepo = "AzureAD/microsoft-authentication-library-for-android";        ApiRepo = "https://api.github.com/repos/AzureAD/microsoft-authentication-library-for-android" },
+    @{ Label = "broker"; Slug = "security/ad-accounts-for-android";                            PrRepo = "msft.ghe.com/security/ad-accounts-for-android";                ApiRepo = "https://msft.ghe.com/api/v3/repos/security/ad-accounts-for-android" }
 )
 
 # ========================================
@@ -64,11 +52,11 @@ $repos = @(
 # ("The Force-Push Confound"). Commit SHA lists are fetched once per PR and cached.
 # ========================================
 $prCommitShaCache = @{}
-function Get-PRCommitShas($slug, $prNum) {
-    $key = "$slug/$prNum"
+function Get-PRCommitShas($apiRepo, $prNum) {
+    $key = "$apiRepo/$prNum"
     if (-not $prCommitShaCache.ContainsKey($key)) {
         try {
-            $shas = gh api "repos/$slug/pulls/$prNum/commits" --paginate --jq '.[].sha' 2>&1
+            $shas = gh api "$apiRepo/pulls/$prNum/commits" --paginate --jq '.[].sha' 2>&1
             $prCommitShaCache[$key] = @($shas | Where-Object { $_ -match '^[0-9a-f]{40}$' })
         } catch {
             $prCommitShaCache[$key] = @()
@@ -95,12 +83,12 @@ function Get-PRCommitShas($slug, $prNum) {
 # Never let this DEMOTE a comment. Commits are fetched once per PR and cached.
 # ========================================
 $prApplyCache = @{}
-function Get-PRApplyCommits($slug, $prNum) {
-    $key = "$slug/$prNum"
+function Get-PRApplyCommits($apiRepo, $prNum) {
+    $key = "$apiRepo/$prNum"
     if (-not $prApplyCache.ContainsKey($key)) {
         $out = @()
         try {
-            $commits = gh api "repos/$slug/pulls/$prNum/commits" --paginate 2>&1 | ConvertFrom-Json
+            $commits = gh api "$apiRepo/pulls/$prNum/commits" --paginate 2>&1 | ConvertFrom-Json
             foreach ($cmt in $commits) {
                 $msg = $cmt.commit.message
                 $tier = $null
@@ -110,7 +98,7 @@ function Get-PRApplyCommits($slug, $prNum) {
                 if ($tier) {
                     $files = @()
                     try {
-                        $det = gh api "repos/$slug/commits/$($cmt.sha)" 2>$null | ConvertFrom-Json
+                        $det = gh api "$apiRepo/commits/$($cmt.sha)" 2>$null | ConvertFrom-Json
                         $files = @($det.files | ForEach-Object { $_.filename })
                     } catch {}
                     $out += [PSCustomObject]@{
@@ -136,6 +124,7 @@ $reviewSummaries = @()
 foreach ($repo in $repos) {
     $label = $repo.Label
     $slug = $repo.Slug
+    $apiRepo = $repo.ApiRepo
     Write-Host "`n========================================" -ForegroundColor Cyan
     Write-Host "Processing: $label ($slug)" -ForegroundColor Cyan
     Write-Host "========================================" -ForegroundColor Cyan
@@ -148,7 +137,7 @@ foreach ($repo in $repos) {
     $prsFile = "$env:TEMP\${label}_prs.json"
     if (-not (Test-Path $prsFile)) {
         Write-Host "  Fetching MERGED PR list ($StartDate..$EndDate)..."
-        gh pr list --repo $slug --state merged --limit 300 --json number,title,author,createdAt,mergedAt,state --search "merged:$StartDate..$EndDate" 2>&1 | Out-File -FilePath $prsFile -Encoding utf8
+        gh pr list --repo $repo.PrRepo --state merged --limit 300 --json number,title,author,createdAt,mergedAt,state --search "merged:$StartDate..$EndDate" 2>&1 | Out-File -FilePath $prsFile -Encoding utf8
     }
     
     $allPRs = Get-Content $prsFile | ConvertFrom-Json
@@ -167,7 +156,7 @@ foreach ($repo in $repos) {
         
         # Get ALL review comments (inline code comments) for this PR
         try {
-            $commentsRaw = gh api "repos/$slug/pulls/$prNum/comments" --paginate 2>&1
+            $commentsRaw = gh api "$apiRepo/pulls/$prNum/comments" --paginate 2>&1
             $comments = $commentsRaw | ConvertFrom-Json
         } catch {
             Write-Host "  PR #$prNum - parse error, skipping" -ForegroundColor Yellow
@@ -206,7 +195,7 @@ foreach ($repo in $repos) {
                 # reviewed (original_commit_id) still in the PR's commit list?
                 $origCommit = $cc.original_commit_id
                 $diffHunk = $cc.diff_hunk
-                $prShas = Get-PRCommitShas $slug $prNum
+                $prShas = Get-PRCommitShas $apiRepo $prNum
                 $reviewedRewritten = $false
                 if ($origCommit -and $prShas.Count -gt 0) {
                     $reviewedRewritten = -not ($prShas -contains $origCommit)
@@ -230,7 +219,7 @@ foreach ($repo in $repos) {
                 if ($ccCreated) {
                     $tierRank = @{ 'native-apply' = 3; 'autofix' = 2; 'coauthor' = 1 }
                     $best = 0
-                    foreach ($ac in (Get-PRApplyCommits $slug $prNum)) {
+                    foreach ($ac in (Get-PRApplyCommits $apiRepo $prNum)) {
                         $acDate = $null; try { $acDate = [datetime]$ac.Date } catch {}
                         if ($acDate -and $acDate -gt $ccCreated -and ($ac.Files -contains $commentPath)) {
                             $applyCandidate = $true
@@ -268,7 +257,7 @@ foreach ($repo in $repos) {
         
         # Also check the review-level summary comments from copilot
         try {
-            $reviewsRaw = gh api "repos/$slug/pulls/$prNum/reviews" 2>&1
+            $reviewsRaw = gh api "$apiRepo/pulls/$prNum/reviews" 2>&1
             $reviews = $reviewsRaw | ConvertFrom-Json
             # Coverage: a PR counts as "reviewed by Copilot" if Copilot posted ANY review
             # (even a body-less APPROVED/COMMENTED), not only ones with a summary body.
@@ -414,12 +403,3 @@ Write-Host "  review_summaries.json ($($reviewSummaries.Count) summaries)"
 Write-Host "================================================================"
 Write-Host "`nNext: Run Phase 2 (precise.ps1) for diff verification," -ForegroundColor Yellow
 Write-Host "then Phase 3 (AI classification of all replied comments)." -ForegroundColor Yellow
-
-# ========================================
-# RESTORE: Switch back to original GitHub account
-# ========================================
-if ($originalAccount) {
-    Write-Host "`nRestoring GitHub CLI to original account '$originalAccount'..." -ForegroundColor Cyan
-    gh auth switch --user $originalAccount 2>&1 | Out-Null
-    Write-Host "  Restored to '$originalAccount'." -ForegroundColor Green
-}

--- a/.github/skills/copilot-review-analyst/scripts/precise.ps1
+++ b/.github/skills/copilot-review-analyst/scripts/precise.ps1
@@ -17,9 +17,9 @@ $OutputDir = "$env:TEMP\copilot-review-analysis"
 $COPILOT_USERS = @("Copilot", "copilot-pull-request-reviewer[bot]")
 
 $repoSlugs = @{
-    "common" = "AzureAD/microsoft-authentication-library-common-for-android"
-    "msal"   = "AzureAD/microsoft-authentication-library-for-android"
-    "broker" = "identity-authnz-teams/ad-accounts-for-android"
+    "common" = "https://api.github.com/repos/AzureAD/microsoft-authentication-library-common-for-android"
+    "msal"   = "https://api.github.com/repos/AzureAD/microsoft-authentication-library-for-android"
+    "broker" = "https://msft.ghe.com/api/v3/repos/security/ad-accounts-for-android"
 }
 
 # Load raw data
@@ -37,7 +37,7 @@ function Get-PRComments($repo, $prNum) {
     if (-not $prCommentApiCache.ContainsKey($key)) {
         $slug = $script:repoSlugs[$repo]
         try {
-            $raw = gh api "repos/$slug/pulls/$prNum/comments" --paginate 2>&1
+            $raw = gh api "$slug/pulls/$prNum/comments" --paginate 2>&1
             $prCommentApiCache[$key] = $raw | ConvertFrom-Json
         } catch {
             $prCommentApiCache[$key] = @()
@@ -51,7 +51,7 @@ function Get-PRHead($repo, $prNum) {
     if (-not $prHeadCache.ContainsKey($key)) {
         $slug = $script:repoSlugs[$repo]
         try {
-            $data = gh api "repos/$slug/pulls/$prNum" --jq '.head.sha' 2>&1
+            $data = gh api "$slug/pulls/$prNum" --jq '.head.sha' 2>&1
             $prHeadCache[$key] = $data.Trim()
         } catch {
             $prHeadCache[$key] = ""
@@ -67,7 +67,7 @@ function Get-FileDiff($repo, $prNum, $commitA, $commitB, $filePath) {
     if (-not $diffCache.ContainsKey($cacheKey)) {
         try {
             # Get the entire compare result (all files)
-            $rawJson = gh api "repos/$slug/compare/${commitA}...${commitB}" 2>&1
+            $rawJson = gh api "$slug/compare/${commitA}...${commitB}" 2>&1
             $compareData = $rawJson | ConvertFrom-Json
             
             # Build a hash of file -> patch data

--- a/.github/skills/copilot-review-analyst/scripts/preflight.ps1
+++ b/.github/skills/copilot-review-analyst/scripts/preflight.ps1
@@ -42,39 +42,29 @@ $ErrorActionPreference = "Continue"
 New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
 
 # ========================================
-# AUTH: switch to the EMU account (has access to all repos incl. private broker).
-# Identical logic to analyze.ps1 so preflight validates the SAME identity the run will use.
+# AUTH: common/msal live on github.com; broker lives on msft.ghe.com.
+# Identical logic to analyze.ps1 so preflight validates the SAME identities the run will use.
 # ========================================
-$originalAccount = gh api user --jq '.login' 2>$null
-$emuAccount = (gh auth status 2>&1 | Select-String 'Logged in to github.com account (\S+_microsoft)' |
-    ForEach-Object { $_.Matches[0].Groups[1].Value } | Select-Object -First 1)
+$originalAccount = $null
 
-if (-not $emuAccount) {
-    Write-Host "ERROR: No EMU account (*_microsoft) found in 'gh auth status'." -ForegroundColor Red
-    Write-Host "  Run: gh auth login  (authenticate with your EMU account)" -ForegroundColor Yellow
+if (-not (gh auth status --hostname github.com 2>&1 | Select-String 'Logged in')) {
+    Write-Host "ERROR: not logged in to github.com." -ForegroundColor Red
+    Write-Host "  Run: gh auth login --hostname github.com" -ForegroundColor Yellow
     exit 1
 }
-if ($originalAccount -ne $emuAccount) {
-    Write-Host "Switching from '$originalAccount' to EMU account '$emuAccount'..." -ForegroundColor Cyan
-    gh auth switch --user $emuAccount 2>&1 | Out-Null
-    $currentAccount = gh api user --jq '.login' 2>$null
-    if ($currentAccount -ne $emuAccount) {
-        Write-Host "ERROR: Failed to switch to EMU account '$emuAccount'." -ForegroundColor Red
-        exit 1
-    }
-    Write-Host "  Switched to '$emuAccount'." -ForegroundColor Green
-} else {
-    Write-Host "Already using EMU account '$emuAccount'." -ForegroundColor Green
-    $originalAccount = $null
+if (-not (gh auth status --hostname msft.ghe.com 2>&1 | Select-String 'Logged in')) {
+    Write-Host "ERROR: not logged in to msft.ghe.com (required for the broker repo)." -ForegroundColor Red
+    Write-Host "  Run: gh auth login --hostname msft.ghe.com" -ForegroundColor Yellow
+    exit 1
 }
 
 $COPILOT_USERS = @("Copilot", "copilot-pull-request-reviewer[bot]")
 $BOT_AUTHORS = @("app/copilot-swe-agent", "Copilot", "dependabot[bot]", "github-actions[bot]")
 
 $repos = @(
-    @{ Label = "common"; Slug = "AzureAD/microsoft-authentication-library-common-for-android" },
-    @{ Label = "msal";   Slug = "AzureAD/microsoft-authentication-library-for-android" },
-    @{ Label = "broker"; Slug = "identity-authnz-teams/ad-accounts-for-android" }
+    @{ Label = "common"; Slug = "AzureAD/microsoft-authentication-library-common-for-android"; PrRepo = "AzureAD/microsoft-authentication-library-common-for-android"; ApiRepo = "https://api.github.com/repos/AzureAD/microsoft-authentication-library-common-for-android" },
+    @{ Label = "msal";   Slug = "AzureAD/microsoft-authentication-library-for-android";        PrRepo = "AzureAD/microsoft-authentication-library-for-android";        ApiRepo = "https://api.github.com/repos/AzureAD/microsoft-authentication-library-for-android" },
+    @{ Label = "broker"; Slug = "security/ad-accounts-for-android";                            PrRepo = "msft.ghe.com/security/ad-accounts-for-android";                ApiRepo = "https://msft.ghe.com/api/v3/repos/security/ad-accounts-for-android" }
 )
 
 Write-Host ""
@@ -88,7 +78,7 @@ $hardFail = $false
 $silentZeroRisk = $false
 
 foreach ($r in $repos) {
-    $label = $r.Label; $slug = $r.Slug
+    $label = $r.Label; $slug = $r.Slug; $apiRepo = $r.ApiRepo
     $repoReadable = $false
     $prListable = $false
     $mergedInWindow = 0
@@ -97,7 +87,7 @@ foreach ($r in $repos) {
     $notes = @()
 
     # (1) repo readable?
-    $repoJson = gh api "repos/$slug" 2>$null
+    $repoJson = gh api "$apiRepo" 2>$null
     if ($LASTEXITCODE -eq 0 -and $repoJson) {
         $repoReadable = $true
     } else {
@@ -107,7 +97,7 @@ foreach ($r in $repos) {
     # (2) merged human PRs in-window?
     $prs = @()
     if ($repoReadable) {
-        $prJson = gh pr list --repo $slug --state merged --search "merged:$StartDate..$EndDate" `
+        $prJson = gh pr list --repo $r.PrRepo --state merged --search "merged:$StartDate..$EndDate" `
             --limit 200 --json number,author,mergedAt 2>$null
         if ($LASTEXITCODE -eq 0 -and $prJson) {
             try { $prs = @($prJson | ConvertFrom-Json) } catch { $prs = @() }
@@ -125,7 +115,7 @@ foreach ($r in $repos) {
             Sort-Object { $_.mergedAt } -Descending | Select-Object -First $SampleSize)
         $sampledPRs = $sample.Count
         foreach ($pr in $sample) {
-            $reviews = gh api "repos/$slug/pulls/$($pr.number)/reviews" --paginate 2>$null | ConvertFrom-Json
+            $reviews = gh api "$apiRepo/pulls/$($pr.number)/reviews" --paginate 2>$null | ConvertFrom-Json
             if ($reviews) {
                 $hasCopilot = $reviews | Where-Object { $_.user.login -in $COPILOT_USERS }
                 if ($hasCopilot) { $prsWithCopilotReview++ }
@@ -169,7 +159,6 @@ foreach ($r in $repos) {
 
 $auditObj = [PSCustomObject]@{
     generatedAt = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ")
-    account     = $emuAccount
     window      = @{ start = $StartDate; end = $EndDate }
     sampleSize  = $SampleSize
     repos       = $audit
@@ -178,9 +167,6 @@ $auditObj = [PSCustomObject]@{
 }
 $auditPath = Join-Path $OutputDir "coverage_audit.json"
 $auditObj | ConvertTo-Json -Depth 6 | Out-File $auditPath -Encoding utf8
-
-# Restore original account if we switched.
-if ($originalAccount) { gh auth switch --user $originalAccount 2>&1 | Out-Null }
 
 Write-Host ""
 Write-Host "  coverage_audit.json -> $auditPath"

--- a/.github/skills/feature-planner/SKILL.md
+++ b/.github/skills/feature-planner/SKILL.md
@@ -26,7 +26,7 @@ Determine which repo(s) each PBI targets based on the architectural layer:
 | common | `AzureAD/microsoft-authentication-library-common-for-android` | Shared utilities, IPC logic, data models, base classes, command architecture, token cache, crypto, telemetry primitives, AIDL contracts |
 | common4j | (same repo as common) | Pure Java/Kotlin shared logic with no Android dependency |
 | msal | `AzureAD/microsoft-authentication-library-for-android` | Client-facing API, AcquireToken/AcquireTokenSilent flows, MSAL-specific controllers, public configuration |
-| broker | `identity-authnz-teams/ad-accounts-for-android` | Broker-side auth processing, PRT acquisition/rotation, device registration, eSTS communication, IPC entry points |
+| broker | `security/ad-accounts-for-android` | Broker-side auth processing, PRT acquisition/rotation, device registration, eSTS communication, IPC entry points |
 | broker4j | (same repo as broker) | Pure Java/Kotlin broker business logic, Protobuf schemas |
 | adal | `AzureAD/azure-activedirectory-library-for-android` | Legacy ADAL changes only (rare — maintenance mode, bug fixes only) |
 | 1ES-Pipelines | `IdentityDivision/Engineering/_git/AuthClientAndroidPipelines` (ADO) | Pipeline YAML changes: release orchestration, hotfix pipelines, templates, validation, publishing, scripts |

--- a/.github/skills/feature-planner/references/dispatch-workflow.md
+++ b/.github/skills/feature-planner/references/dispatch-workflow.md
@@ -36,7 +36,7 @@ Extract the target repository from the PBI description. The PBI template include
 "Target Repository" section with the format:
 - `AzureAD/microsoft-authentication-library-common-for-android` → common
 - `AzureAD/microsoft-authentication-library-for-android` → msal
-- `identity-authnz-teams/ad-accounts-for-android` → broker
+- `security/ad-accounts-for-android` → broker
 - `AzureAD/azure-activedirectory-library-for-android` → adal
 
 ### Step 3: Check Dependencies

--- a/.github/skills/oncall-weekly-telemetry-report/SKILL.md
+++ b/.github/skills/oncall-weekly-telemetry-report/SKILL.md
@@ -306,7 +306,7 @@ For each candidate PR, **read the diff** to confirm it touches the throw site / 
 | Repo | URL pattern |
 |------|-------------|
 | `common/` | `https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/<num>` |
-| `broker/` | `https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/<num>` |
+| `broker/` | `https://msft.ghe.com/security/ad-accounts-for-android/pull/<num>` |
 | `msal/` | `https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/<num>` |
 | `adal/` | `https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/<num>` |
 

--- a/.github/skills/oncall-weekly-telemetry-report/assets/scripts/find-suspect-prs.ps1
+++ b/.github/skills/oncall-weekly-telemetry-report/assets/scripts/find-suspect-prs.ps1
@@ -67,7 +67,7 @@ if (-not $RepoRoot) {
 if (-not $GrepRegex) { $GrepRegex = [regex]::Escape($Symbol) }
 
 $repos = @(
-    @{ Name='broker'; Path=(Join-Path $RepoRoot 'broker'); UrlBase='https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/' }
+    @{ Name='broker'; Path=(Join-Path $RepoRoot 'broker'); UrlBase='https://msft.ghe.com/security/ad-accounts-for-android/pull/' }
     @{ Name='common'; Path=(Join-Path $RepoRoot 'common'); UrlBase='https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/' }
 )
 
@@ -80,7 +80,7 @@ if ($availableRepos.Count -eq 0) {
 Neither broker/ nor common/ found under -RepoRoot $RepoRoot.
 
 Expected layout:
-  $RepoRoot\broker\   (clone of identity-authnz-teams/ad-accounts-for-android)
+  $RepoRoot\broker\   (clone of security/ad-accounts-for-android)
   $RepoRoot\common\   (clone of AzureAD/microsoft-authentication-library-common-for-android)
 
 Pass -RepoRoot pointing at the parent of those two clones. The android-complete

--- a/.github/skills/oncall-weekly-telemetry-report/assets/templates/report-template.html
+++ b/.github/skills/oncall-weekly-telemetry-report/assets/templates/report-template.html
@@ -590,7 +590,7 @@
       <tr><td><code>429</code> (eSTS rate-limit)</td><td class="num">~10</td><td class="num warn">218 K (week Mar 22)</td><td class="num good">2.5 K</td><td><svg width="160" height="28" viewBox="0 0 160 28" xmlns="http://www.w3.org/2000/svg"><path d="M2,26 L24.285714285714285,25.543803291327453 L46.57142857142857,23.002120180261215 L68.85714285714286,2 L91.14285714285714,23.690049838003542 L113.42857142857142,24.35132580103347 L135.71428571428572,10.1533872403697 L158,25.724211357190715 L158,28 L2,28 Z" fill="#bf8700" opacity="0.12"/><path d="M2,26 L24.285714285714285,25.543803291327453 L46.57142857142857,23.002120180261215 L68.85714285714286,2 L91.14285714285714,23.690049838003542 L113.42857142857142,24.35132580103347 L135.71428571428572,10.1533872403697 L158,25.724211357190715" fill="none" stroke="#bf8700" stroke-width="1.4"/><circle cx="158" cy="25.724211357190715" r="2" fill="#bf8700"/></svg></td></tr>
     </tbody>
   </table>
-  <p style="margin-top:6px;font-size:12.5px;">Both <code>unknown_authority</code> (common <a href="https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/3082" target="_blank">#3082</a> ABBA deadlock fix) and <code>timed_out_execution</code> (broker <a href="https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/141" target="_blank">#141</a> flight gating) are recovering. <strong>Recommendation:</strong> add Aria guardrail at &gt;1M devices/week for <code>unknown_authority</code> to detect any future excursion early.</p>
+  <p style="margin-top:6px;font-size:12.5px;">Both <code>unknown_authority</code> (common <a href="https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/3082" target="_blank">#3082</a> ABBA deadlock fix) and <code>timed_out_execution</code> (broker <a href="https://msft.ghe.com/security/ad-accounts-for-android/pull/141" target="_blank">#141</a> flight gating) are recovering. <strong>Recommendation:</strong> add Aria guardrail at &gt;1M devices/week for <code>unknown_authority</code> to detect any future excursion early.</p>
 </div>
 
 <div class="callout win">
@@ -605,7 +605,7 @@
       <tr><td><code>null_object</code>, <code>device_network_not_available</code>, <code>access_denied</code>, <code>ONLY_SUPPORTS_ACCOUNT_MANAGER_ERROR_CODE</code>, <code>invalid_key</code></td><td colspan="3" class="muted">all −17% to −78% over 8 wks (see appendix)</td><td></td></tr>
     </tbody>
   </table>
-  <p style="margin-top:6px;font-size:12.5px;"><strong>Note:</strong> the <code>timed_out</code> drop and <code>timed_out_execution</code> climb are partly the same event — broker <a href="https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/141" target="_blank">#141</a> reclassifies legacy <code>timed_out</code> into the more specific <code>timed_out_execution</code>. The reclassification is net-neutral but the new code is louder; treat the <code>timed_out</code> "win" with caution.</p>
+  <p style="margin-top:6px;font-size:12.5px;"><strong>Note:</strong> the <code>timed_out</code> drop and <code>timed_out_execution</code> climb are partly the same event — broker <a href="https://msft.ghe.com/security/ad-accounts-for-android/pull/141" target="_blank">#141</a> reclassifies legacy <code>timed_out</code> into the more specific <code>timed_out_execution</code>. The reclassification is net-neutral but the new code is louder; treat the <code>timed_out</code> "win" with caution.</p>
 </div>
 
 <div class="callout">
@@ -687,7 +687,7 @@
     <div class="attr-tags"><span class="tag tag-bad">60d regression</span><span class="tag tag-warn">peak-then-recover</span><span class="tag tag-info">AppManager-heavy</span></div>
   </div>
   <div class="attr-body">
-    <div class="attr-verdict bad"><strong>Verdict — 60d regression with WoW recovery underway.</strong> Almost entirely on <code>AcquireTokenSilent</code> (99.9%). The peak at 143 M devices (week of Apr 12) and subsequent drop to 53.4 M is consistent with broker <a href="https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/141" target="_blank">#141</a> (HTTP cancellation on ATS command-level timeout) being flight-rolled out and then partially gated back. AppManager (Link to Windows) is the dominant active broker (53% this week, was 69% prior), and most-affected calling app: Outlook 32% / AppManager 25% / Teams 24%. <strong>Action:</strong> confirm the flight rollout schedule for #141 and check whether the timeout threshold needs tuning before re-enabling broadly. Watch for downstream client retry storms (it converts silent thread-leak into an explicit error → callers must retry cleanly).</div>
+    <div class="attr-verdict bad"><strong>Verdict — 60d regression with WoW recovery underway.</strong> Almost entirely on <code>AcquireTokenSilent</code> (99.9%). The peak at 143 M devices (week of Apr 12) and subsequent drop to 53.4 M is consistent with broker <a href="https://msft.ghe.com/security/ad-accounts-for-android/pull/141" target="_blank">#141</a> (HTTP cancellation on ATS command-level timeout) being flight-rolled out and then partially gated back. AppManager (Link to Windows) is the dominant active broker (53% this week, was 69% prior), and most-affected calling app: Outlook 32% / AppManager 25% / Teams 24%. <strong>Action:</strong> confirm the flight rollout schedule for #141 and check whether the timeout threshold needs tuning before re-enabling broadly. Watch for downstream client retry storms (it converts silent thread-leak into an explicit error → callers must retry cleanly).</div>
     <div class="attr-dims"><div class="dim"><div class="dim-label">Span</div><div class="dim-row dominant"><span class="dim-name">AcquireTokenSilent</span><span class="dim-pct">99.9%</span></div>
         <div class="dim-bar-track"><div class="dim-bar-fill dominant" style="width:99.9%"></div></div>
 <div class="dim-row "><span class="dim-name">ATISilently</span><span class="dim-pct">0.1%</span></div>
@@ -717,7 +717,7 @@
       <div class="code-attr-title">Code attribution</div>
       <div class="pr-list"><div class="pr-card">
       <div class="pr-conf pr-conf-high">high</div>
-      <div class="pr-body"><a class="pr-id" href="https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/141" target="_blank" rel="noopener">broker#141</a> <span class="pr-title">Add flight-gated HTTP cancellation on ATS command-level timeout to eliminate zombie worker threads (AB#3542516)</span>
+      <div class="pr-body"><a class="pr-id" href="https://msft.ghe.com/security/ad-accounts-for-android/pull/141" target="_blank" rel="noopener">broker#141</a> <span class="pr-title">Add flight-gated HTTP cancellation on ATS command-level timeout to eliminate zombie worker threads (AB#3542516)</span>
         <div class="pr-why">This PR explicitly converts long-running ATS calls into timed_out_execution. The 60d trajectory matches the flight rollout perfectly. The reciprocal drop in legacy timed_out (-86%) confirms the reclassification.</div>
       </div>
     </div></div>
@@ -837,7 +837,7 @@
     <div class="attr-tags"><span class="tag tag-warn">60d regression</span><span class="tag tag-info">silent path</span><span class="tag tag-info">LTW + Authenticator</span></div>
   </div>
   <div class="attr-body">
-    <div class="attr-verdict bad"><strong>Verdict — Steady 60d climb in NPE crashes; small absolute volume but trajectory worth flagging.</strong> Span: <code>AcquireTokenSilent</code> 98%. Active broker: AppManager (LTW) 53% / Authenticator 26% / Intune CP 20%. Calling app: AppManager 35% / Teams 28% / Outlook 21%. The over-representation of LTW (53% vs ~5-10% fleet share for that active broker) is a strong signal — there's likely a null path specific to the LTW broker process. <strong>Action:</strong> bucket by error_location / stack-trace prefix and route to LTW team. Cite <a href="https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/141" target="_blank">broker #141</a> as a possible secondary contributor (timeout cancellation can interact with deferred work that holds a null reference).</div>
+    <div class="attr-verdict bad"><strong>Verdict — Steady 60d climb in NPE crashes; small absolute volume but trajectory worth flagging.</strong> Span: <code>AcquireTokenSilent</code> 98%. Active broker: AppManager (LTW) 53% / Authenticator 26% / Intune CP 20%. Calling app: AppManager 35% / Teams 28% / Outlook 21%. The over-representation of LTW (53% vs ~5-10% fleet share for that active broker) is a strong signal — there's likely a null path specific to the LTW broker process. <strong>Action:</strong> bucket by error_location / stack-trace prefix and route to LTW team. Cite <a href="https://msft.ghe.com/security/ad-accounts-for-android/pull/141" target="_blank">broker #141</a> as a possible secondary contributor (timeout cancellation can interact with deferred work that holds a null reference).</div>
     <div class="attr-dims"><div class="dim"><div class="dim-label">Span</div><div class="dim-row dominant"><span class="dim-name">AcquireTokenSilent</span><span class="dim-pct">98.5%</span></div>
         <div class="dim-bar-track"><div class="dim-bar-fill dominant" style="width:98.5%"></div></div>
 <div class="dim-row "><span class="dim-name">DeviceRegistrationApi</span><span class="dim-pct">1.0%</span></div>
@@ -867,7 +867,7 @@
       <div class="code-attr-title">Code attribution</div>
       <div class="pr-list"><div class="pr-card">
       <div class="pr-conf pr-conf-low">low</div>
-      <div class="pr-body"><a class="pr-id" href="https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/141" target="_blank" rel="noopener">broker#141</a> <span class="pr-title">HTTP cancellation on ATS timeout (LTW broker process)</span>
+      <div class="pr-body"><a class="pr-id" href="https://msft.ghe.com/security/ad-accounts-for-android/pull/141" target="_blank" rel="noopener">broker#141</a> <span class="pr-title">HTTP cancellation on ATS timeout (LTW broker process)</span>
         <div class="pr-why">Active broker is heavily LTW (53% vs ~7% fleet share). The same ATS timeout cancellation path may be racing with a null-checked reference in a deferred callback. Needs stack-trace bucketing to confirm.</div>
       </div>
     </div><div class="pr-card">

--- a/.github/skills/pbi-dispatcher/SKILL.md
+++ b/.github/skills/pbi-dispatcher/SKILL.md
@@ -48,7 +48,7 @@ After installation completes, verify with `gh --version`, then prompt authentica
 ```powershell
 $config = Get-Content ".github/developer-local.json" -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json
 $publicUser = $config.github_accounts.AzureAD
-$emuUser = $config.github_accounts.'identity-authnz-teams'
+$gheUser = $config.github_accounts.'msft.ghe.com'
 ```
 
 **Step 2: Discover from `gh auth status`** (zero-config if logged in):
@@ -57,15 +57,15 @@ $ghStatus = gh auth status 2>&1
 # Parse output for logged-in accounts on each host
 # Look for lines like: "Logged in to github.com account <username>"
 ```
-Map accounts to orgs:
-- Non-EMU account (no `_` suffix) → `AzureAD/*` repos
-- EMU account (ends with `_microsoft` or similar) → `identity-authnz-teams/*` repos
+Map accounts to hosts:
+- Account logged in to `github.com` → `AzureAD/*` repos
+- Account logged in to `msft.ghe.com` → `security/ad-accounts-for-android` (broker)
 
 **Step 3: Prompt the developer** (fallback — save for next time):
 If neither Step 1 nor Step 2 yields both accounts, ask:
 > "I need your GitHub usernames for dispatching:
-> 1. **Public GitHub** (for AzureAD/* repos like common, msal, adal): ___
-> 2. **GitHub Enterprise / EMU** (for identity-authnz-teams/* repos like broker): ___"
+> 1. **github.com** (for AzureAD/* repos like common, msal, adal): ___
+> 2. **msft.ghe.com** (for `security/ad-accounts-for-android`, i.e. broker): ___"
 
 After receiving the answer, offer to save:
 > "Save these to `.github/developer-local.json` so you don't have to enter them again? (Y/n)"
@@ -75,7 +75,7 @@ If yes, write the config file:
 {
   "github_accounts": {
     "AzureAD": "<public_username>",
-    "identity-authnz-teams": "<emu_username>"
+    "msft.ghe.com": "<ghe_username>"
   }
 }
 ```
@@ -84,6 +84,7 @@ If yes, write the config file:
 > "You're not signed in to GitHub CLI. Please run:
 > ```
 > gh auth login --hostname github.com
+> gh auth login --hostname msft.ghe.com
 > ```
 > Then try dispatching again."
 
@@ -95,7 +96,7 @@ Do NOT attempt to proceed without valid accounts — fail fast with clear instru
 |---------------|-------------|--------------|
 | common / common4j | `AzureAD/microsoft-authentication-library-common-for-android` | Public (AzureAD) |
 | msal | `AzureAD/microsoft-authentication-library-for-android` | Public (AzureAD) |
-| broker / broker4j / AADAuthenticator | `identity-authnz-teams/ad-accounts-for-android` | EMU (identity-authnz-teams) |
+| broker / broker4j / AADAuthenticator | `security/ad-accounts-for-android` | msft.ghe.com |
 | adal | `AzureAD/azure-activedirectory-library-for-android` | Public (AzureAD) |
 
 ## Workflow
@@ -107,17 +108,17 @@ PBI description — it will be needed for the dispatch prompt.
 ### 2. Check Dependencies
 For each PBI, check if its dependencies (other AB# IDs) have merged PRs. Skip blocked PBIs.
 
-### 3. Switch gh Account + Dispatch to Copilot Agent
+### 3. Select gh Host/Account + Dispatch to Copilot Agent
 
 For each ready PBI:
 
-**Step 1: Switch to the correct gh account** (using the discovered username from above):
+**Step 1: Target the correct gh host** (using the discovered username from above):
 ```bash
-# For AzureAD/* repos (common, msal, adal):
-gh auth switch --user <discovered_public_username>
+# For AzureAD/* repos (common, msal, adal) on github.com:
+gh auth switch --hostname github.com --user <discovered_public_username>
 
-# For identity-authnz-teams/* repos (broker):
-gh auth switch --user <discovered_emu_username>
+# For security/ad-accounts-for-android (broker) on msft.ghe.com:
+# no account switch — add --hostname msft.ghe.com to every gh command
 ```
 
 **Step 2: Dispatch using `gh agent-task create` (PREFERRED — requires gh v2.80+):**

--- a/.github/skills/release-monitoring-report/assets/scripts/find-suspect-prs.ps1
+++ b/.github/skills/release-monitoring-report/assets/scripts/find-suspect-prs.ps1
@@ -115,7 +115,7 @@ if (-not $RepoRoot) {
 if (-not $GrepRegex) { $GrepRegex = [regex]::Escape($Symbol) }
 
 $repoDefs = @(
-    @{ Name='broker';        Path=(Join-Path $RepoRoot 'broker');        UrlBase='https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/' }
+    @{ Name='broker';        Path=(Join-Path $RepoRoot 'broker');        UrlBase='https://msft.ghe.com/security/ad-accounts-for-android/pull/' }
     @{ Name='common';        Path=(Join-Path $RepoRoot 'common');        UrlBase='https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/' }
     @{ Name='authenticator'; Path=(Join-Path $RepoRoot 'authenticator'); UrlBase='https://msazure.visualstudio.com/One/_git/AD-MFA-phonefactor-phoneApp-android/pullrequest/'; Ado=$true }
 )
@@ -141,7 +141,7 @@ if ($availableRepos.Count -eq 0) {
 None of the requested repos ($($repoDefs.Name -join ', ')) found under -RepoRoot $RepoRoot.
 
 Expected layout:
-  $RepoRoot\broker\          (clone of identity-authnz-teams/ad-accounts-for-android)
+  $RepoRoot\broker\          (clone of security/ad-accounts-for-android)
   $RepoRoot\common\          (clone of AzureAD/microsoft-authentication-library-common-for-android)
   $RepoRoot\authenticator\   (clone of msazure One/AD-MFA-phonefactor-phoneApp-android)
 

--- a/.github/skills/release-monitoring-report/assets/templates/report-template.html
+++ b/.github/skills/release-monitoring-report/assets/templates/report-template.html
@@ -834,7 +834,7 @@
         <div class="pr-card">
           <span class="pr-conf pr-conf-low">low-med</span>
           <div class="pr-body">
-            <a class="pr-id" href="https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/176">broker#176</a>
+            <a class="pr-id" href="https://msft.ghe.com/security/ad-accounts-for-android/pull/176">broker#176</a>
             <span class="pr-title">supportsBoundService default → true</span>
             <div class="pr-meta">68126018c · Pedro Romero Vargas · AB#3571860</div>
             <div class="pr-why">Flips <code>supportsBoundService</code> from <code>false</code> to <code>true</code> in <code>DeviceRegistrationClientApplication</code>, changing IPC-strategy selection toward the bound-service path — a plausible driver of the <code>interaction_required</code> rise on the <code>MSAL_PerformIpcStrategy</code> span (+3.38 pp). Needs eSTS-side confirmation.</div>
@@ -843,7 +843,7 @@
         <div class="pr-card">
           <span class="pr-conf pr-conf-none">excluded</span>
           <div class="pr-body">
-            <a class="pr-id" href="https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/174">broker#174</a>
+            <a class="pr-id" href="https://msft.ghe.com/security/ad-accounts-for-android/pull/174">broker#174</a>
             <span class="pr-title">null object get cache record + 2023 common#2222 false-positive</span>
             <div class="pr-meta">9c9906686 · @siddhijain · AB#3607178</div>
             <div class="pr-why">broker#174 touches the silent cache path but addresses a <em>different</em> code (<code>null_object</code>), <em>reduces</em> errors, and is gated to <code>SdkType.MSAL_CPP</code> (OneAuth) — not the Authenticator MSAL path. Note: the 2023 <code>common#2222</code> (PoP re-key) is <strong>not in this release</strong> — it surfaced earlier only because the range tool resolved common's own <code>v16.x</code> tag namespace instead of the submodule pointer.</div>

--- a/AI Driven Development Guide.md
+++ b/AI Driven Development Guide.md
@@ -170,9 +170,9 @@ The setup script handles all of these, but for reference:
 
 ### GitHub Authentication
 
-You need two GitHub accounts authenticated via `gh`:
-- **Public** (e.g., `johndoe`) — for AzureAD/* repos (common, msal, adal)
-- **EMU** (e.g., `johndoe_microsoft`) — for identity-authnz-teams/* repos (broker)
+You need two GitHub hosts authenticated via `gh`:
+- **github.com** (e.g., `johndoe`) — for AzureAD/* repos (common, msal, adal)
+- **msft.ghe.com** (e.g., `johndoe_microsoft`) — for `security/ad-accounts-for-android` (broker). Sign in with `gh auth login --hostname msft.ghe.com`.
 
 The setup script discovers logged-in accounts and saves them to `.github/developer-local.json`.
 

--- a/azure-pipelines/continuous-delivery/auth-client-android-daily.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-daily.yml
@@ -14,10 +14,10 @@ resources:
       ref: dev
       endpoint: ANDROID_GITHUB
     - repository: broker
-      type: github
-      name: AzureAD/ad-accounts-for-android
+      type: githubenterprise
+      name: security/ad-accounts-for-android
       ref: dev
-      endpoint: ANDROID_GITHUB
+      endpoint: MSFT_GHE_SECURITY
     - repository: msal
       type: github
       name: AzureAD/microsoft-authentication-library-for-android

--- a/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/auth-client-android-dev.yml
@@ -20,10 +20,10 @@ resources:
       ref: dev
       endpoint: ANDROID_GITHUB
     - repository: broker
-      type: github
-      name: AzureAD/ad-accounts-for-android
+      type: githubenterprise
+      name: security/ad-accounts-for-android
       ref: dev
-      endpoint: ANDROID_GITHUB
+      endpoint: MSFT_GHE_SECURITY
     - repository: msal
       type: github
       name: AzureAD/microsoft-authentication-library-for-android

--- a/azure-pipelines/continuous-delivery/flighted-auth-client-android-dev.yml
+++ b/azure-pipelines/continuous-delivery/flighted-auth-client-android-dev.yml
@@ -22,10 +22,10 @@ resources:
       ref: dev
       endpoint: ANDROID_GITHUB
     - repository: broker
-      type: github
-      name: AzureAD/ad-accounts-for-android
+      type: githubenterprise
+      name: security/ad-accounts-for-android
       ref: dev
-      endpoint: ANDROID_GITHUB
+      endpoint: MSFT_GHE_SECURITY
     - repository: msal
       type: github
       name: AzureAD/microsoft-authentication-library-for-android

--- a/azure-pipelines/instrumented-tests-multistage.yml
+++ b/azure-pipelines/instrumented-tests-multistage.yml
@@ -32,10 +32,10 @@ resources:
     ref: $(adal_branch)
     endpoint: ANDROID_GITHUB
   - repository: broker
-    type: github
-    name: AzureAD/ad-accounts-for-android
+    type: githubenterprise
+    name: security/ad-accounts-for-android
     ref: $(broker_branch)
-    endpoint: ANDROID_GITHUB
+    endpoint: MSFT_GHE_SECURITY
 
 parameters:
 - name: listOfApis

--- a/azure-pipelines/test-app/broker-host.yml
+++ b/azure-pipelines/test-app/broker-host.yml
@@ -51,10 +51,10 @@ resources:
     ref: dev
     endpoint: ANDROID_GITHUB
   - repository: broker
-    type: github
-    name: AzureAD/ad-accounts-for-android
+    type: githubenterprise
+    name: security/ad-accounts-for-android
     ref: dev
-    endpoint: ANDROID_GITHUB
+    endpoint: MSFT_GHE_SECURITY
 
 jobs:
 - job: brokerhost

--- a/azure-pipelines/test-app/java-linux-test-app.yml
+++ b/azure-pipelines/test-app/java-linux-test-app.yml
@@ -18,10 +18,10 @@ schedules:
 resources:
   repositories:
   - repository: broker
-    type: github
-    name: AzureAD/ad-accounts-for-android
+    type: githubenterprise
+    name: security/ad-accounts-for-android
     ref: dev
-    endpoint: ANDROID_GITHUB
+    endpoint: MSFT_GHE_SECURITY
 
 jobs:
 - job: build_deb

--- a/azure-pipelines/test-app/microsoft-identity-diagnostics-cd.yml
+++ b/azure-pipelines/test-app/microsoft-identity-diagnostics-cd.yml
@@ -19,10 +19,10 @@ schedules:
 resources:
   repositories:
     - repository: broker
-      type: github
-      name: AzureAD/ad-accounts-for-android
+      type: githubenterprise
+      name: security/ad-accounts-for-android
       ref: $(local_ad_accounts_branch)
-      endpoint: ANDROID_GITHUB
+      endpoint: MSFT_GHE_SECURITY
 
 jobs:
   - job: build_deb

--- a/azure-pipelines/test-app/msal-test-app.yml
+++ b/azure-pipelines/test-app/msal-test-app.yml
@@ -46,10 +46,10 @@ resources:
     endpoint: ANDROID_GITHUB
     # We need broker to get otelexporter
   - repository: broker
-    type: github
-    name: AzureAD/ad-accounts-for-android
+    type: githubenterprise
+    name: security/ad-accounts-for-android
     ref: dev
-    endpoint: ANDROID_GITHUB
+    endpoint: MSFT_GHE_SECURITY
 
 
 jobs:

--- a/azure-pipelines/ui-automation/broker-test.yml
+++ b/azure-pipelines/ui-automation/broker-test.yml
@@ -24,10 +24,10 @@ resources:
     ref: $(msal_branch)
     endpoint: ANDROID_GITHUB
   - repository: broker
-    type: github
-    name: AzureAD/ad-accounts-for-android
+    type: githubenterprise
+    name: security/ad-accounts-for-android
     ref: $(broker_branch)
-    endpoint: ANDROID_GITHUB
+    endpoint: MSFT_GHE_SECURITY
 
 variables:
   engineeringProjectId: 'fac9d424-53d2-45c0-91b5-ef6ba7a6bf26'

--- a/docs/AzureDevOps/Compliance/OSSReviews.md
+++ b/docs/AzureDevOps/Compliance/OSSReviews.md
@@ -39,7 +39,7 @@ In this pipeline, we can find a _Generate Lockfile_ task for each stage, this ta
 
 Android Identity governed repositories are found in the [Engineering project](https://identitydivision.visualstudio.com/Engineering/) in Azure DevOps, and the repositories are the following:
 
-- azuread/ad-accounts-for-android
+- security/ad-accounts-for-android
 - azuread/android-complete
 - azuread/azure-activedirectory-library-for-android
 - azuread/microsoft-authentication-library-common-for-android

--- a/docs/broker-remote-migration.md
+++ b/docs/broker-remote-migration.md
@@ -1,0 +1,151 @@
+# Broker Remote Migration: `github.com` → `msft.ghe.com`
+
+The broker repository moved from the public GitHub EMU org to Microsoft GitHub Enterprise (Proxima):
+
+| | Old | New |
+|---|---|---|
+| **Host** | `github.com` | `msft.ghe.com` |
+| **Slug** | `identity-authnz-teams/ad-accounts-for-android` | `security/ad-accounts-for-android` |
+| **URL** | https://github.com/identity-authnz-teams/ad-accounts-for-android | https://msft.ghe.com/security/ad-accounts-for-android |
+
+Only the **broker** module moved. `msal`, `common`, and `adal` stay on public `github.com/AzureAD`.
+
+---
+
+## TL;DR — repoint your existing checkout (no re-clone)
+
+Run from `android-complete/broker`:
+
+```powershell
+# 1. Authenticate gh against the new host (one-time, opens browser)
+gh auth login --hostname msft.ghe.com --git-protocol https --web
+
+# 2. Point the broker remote at the new URL
+cd C:\repos\android-complete\broker
+git remote set-url origin https://msft.ghe.com/security/ad-accounts-for-android.git
+
+# 3. Verify + refresh
+git remote -v
+git fetch origin
+```
+
+That's it — your branches, stashes, and local commits are untouched. `git pull`/`push` now hit Proxima.
+
+---
+
+## Let Copilot do it for you
+
+If you'd rather not run the steps by hand, use the shared prompt at
+[`.github/prompts/broker-ghe-migrate.prompt.md`](../.github/prompts/broker-ghe-migrate.prompt.md):
+in VS Code Copilot Chat type **`/broker-ghe-migrate`** (or open the file and copy-paste its
+body). It authenticates to `msft.ghe.com`, repoints the broker `git remote`, then pulls
+latest on `android-complete` / `broker` / `common` (which already carry the migrated
+pipeline YAML and `gh`/`curl` references), and finally fixes your per-developer
+`developer-local.json`. It does **not** hand-edit tracked files or touch historical
+`changes.txt`/PR links, and stops for your review before committing or pushing.
+
+---
+
+## One-time prerequisites
+
+1. **Access.** Request the **`security/ad-accounts-for-android`** access package in My Access: https://myaccess.microsoft.com/@msesmecloud.onmicrosoft.com#/access-packages/0cf20674-39ff-406b-a447-e31b1923f985 — approval grants access to the repo on `msft.ghe.com`. Once granted, confirm you can open https://msft.ghe.com/security/ad-accounts-for-android in a browser before continuing.
+2. **gh CLI ≥ 2.x.** Check with `gh --version`. The EMU account switch trick is gone — `gh` now routes by **host**, so you stay logged into both `github.com` and `msft.ghe.com` at the same time.
+3. **Git credential helper.** If you use the Git Credential Manager, the first `git fetch` after the remote change will prompt you to authenticate to `msft.ghe.com` — complete that once and it's cached.
+
+Verify both hosts are authenticated:
+
+```powershell
+gh auth status --hostname github.com
+gh auth status --hostname msft.ghe.com
+```
+
+---
+
+## Fresh setup (new machine / new clone)
+
+The `git droidSetup` alias in `.gitconfig` already points at the new URL, so a fresh `droidSetup` just works **once you're logged into `msft.ghe.com`**. If you clone broker manually:
+
+```powershell
+git clone -b dev https://msft.ghe.com/security/ad-accounts-for-android.git broker
+```
+
+---
+
+## Working with the broker repo day-to-day
+
+Because broker lives on a different host, add `--hostname msft.ghe.com` to `gh` commands that talk to it (PRs, API calls, releases):
+
+```powershell
+# List / view PRs on broker
+gh pr list  --repo msft.ghe.com/security/ad-accounts-for-android
+gh pr view <n> --repo msft.ghe.com/security/ad-accounts-for-android
+
+# Raw API calls use the GHE API base
+gh api --hostname msft.ghe.com repos/security/ad-accounts-for-android/pulls/<n>
+```
+
+For `msal`/`common`/`adal` keep using plain `github.com` (no `--hostname` needed).
+
+---
+
+## Azure DevOps pipelines (already updated in this repo)
+
+The pipeline YAML now references the new location. **A pipeline admin must create the service connection once**, then everything resolves:
+
+- **New service connection name:** `MSFT_GHE_SECURITY` (GitHub Enterprise Server type, pointing at `https://msft.ghe.com`, org `security`).
+  - Replaces the old `github-inside-microsoft` GitHub connection for broker.
+- **Repository resources** changed from:
+  ```yaml
+  - repository: broker
+    type: github
+    name: identity-authnz-teams/ad-accounts-for-android
+    endpoint: github-inside-microsoft   # or ANDROID_GITHUB
+  ```
+  to:
+  ```yaml
+  - repository: broker
+    type: githubenterprise
+    name: security/ad-accounts-for-android
+    endpoint: MSFT_GHE_SECURITY
+  ```
+- **`GitHubRelease@1` tasks** and release-note existence checks now use `gitHubConnection: 'MSFT_GHE_SECURITY'` and the `https://msft.ghe.com/api/v3/...` REST base.
+
+> ⚠️ Until the `MSFT_GHE_SECURITY` service connection exists and is authorized for the pipelines, broker-dependent pipelines will fail at checkout. Coordinate the connection creation with the pipeline change rollout.
+
+---
+
+## What was changed in the codebase (for reviewers)
+
+| Area | Files |
+|---|---|
+| Clone alias | `.gitconfig` (`droidSetup`) |
+| AI-orchestrator docs/skills | `.github/copilot-instructions.md`, `.github/agents/*`, `.github/prompts/*`, `.github/skills/{pbi-dispatcher,feature-planner,copilot-review-analyst,oncall-weekly-telemetry-report,release-monitoring-report}/**`, `AI Driven Development Guide.md`, `scripts/setup-ai-orchestrator.ps1` |
+| Legacy pipelines | `azure-pipelines/**` (broker repo resources → `githubenterprise` + `MSFT_GHE_SECURITY`) |
+| Broker repo | `azure-pipelines/pull-request-validation/*`, `.github/workflows/validate-pr-ab-id.yml` (host-agnostic API URL), gradle POM URLs, doc links |
+| 1ES pipelines | `AuthClientAndroidPipelines/**` (resources, release-note publish steps, docs) |
+| Account routing | The `identity-authnz-teams` account key is now `msft.ghe.com` in `developer-local.json`; scripts authenticate per-host instead of `gh auth switch`-ing to an EMU account |
+
+Historical changelog entries (`changes.txt`) were intentionally **not** rewritten — their links are historical records.
+
+### `.github/developer-local.json` (per-developer, gitignored)
+
+Update the key from the old org to the new host:
+
+```json
+{
+  "github_accounts": {
+    "AzureAD": "<your_public_username>",
+    "msft.ghe.com": "<your_ghe_username>"
+  }
+}
+```
+
+---
+
+## Rollback
+
+If you need to point back during the grace period:
+
+```powershell
+git remote set-url origin https://github.com/identity-authnz-teams/ad-accounts-for-android.git
+```

--- a/scripts/setup-ai-orchestrator.ps1
+++ b/scripts/setup-ai-orchestrator.ps1
@@ -128,17 +128,17 @@ if (Test-Path $devLocalPath) {
         $config = Get-Content $devLocalPath -Raw | ConvertFrom-Json
         $ghAccounts = @{
             "AzureAD" = $config.github_accounts.AzureAD
-            "identity-authnz-teams" = $config.github_accounts."identity-authnz-teams"
+            "msft.ghe.com" = $config.github_accounts."msft.ghe.com"
         }
         Write-Host "  OK: developer-local.json exists" -ForegroundColor Green
         Write-Host "    AzureAD account: $($ghAccounts['AzureAD'])" -ForegroundColor DarkGray
-        Write-Host "    EMU account: $($ghAccounts['identity-authnz-teams'])" -ForegroundColor DarkGray
+        Write-Host "    msft.ghe.com account: $($ghAccounts['msft.ghe.com'])" -ForegroundColor DarkGray
     } catch {
         Write-Host "  WARNING: developer-local.json exists but couldn't be parsed" -ForegroundColor Yellow
     }
 }
 
-if (-not $ghAccounts["AzureAD"] -or -not $ghAccounts["identity-authnz-teams"]) {
+if (-not $ghAccounts["AzureAD"] -or -not $ghAccounts["msft.ghe.com"]) {
     Write-Host "  GitHub accounts not configured. Let's set them up." -ForegroundColor Yellow
     Write-Host ""
 
@@ -192,36 +192,36 @@ if (-not $ghAccounts["AzureAD"] -or -not $ghAccounts["identity-authnz-teams"]) {
         }
     }
 
-    # EMU account (identity-authnz-teams repos)
-    if (-not $ghAccounts["identity-authnz-teams"]) {
+    # GHE.com account (security/ad-accounts-for-android, i.e. broker)
+    if (-not $ghAccounts["msft.ghe.com"]) {
         Write-Host ""
-        Write-Host "  You need an EMU GitHub account for identity-authnz-teams/* repos (broker)." -ForegroundColor Cyan
+        Write-Host "  You need an msft.ghe.com account for security/ad-accounts-for-android (broker)." -ForegroundColor Cyan
         if ($discoveredEmu) {
             $confirm = Read-Host "  Use discovered account '$discoveredEmu'? (Y/n)"
             if ($confirm -ne "n") {
                 $emuUser = $discoveredEmu
             } else {
-                $emuUser = Read-Host "  Enter your EMU GitHub username"
+                $emuUser = Read-Host "  Enter your msft.ghe.com username"
             }
         } else {
-            $emuUser = Read-Host "  Enter your EMU GitHub username (e.g., johndoe_microsoft)"
+            $emuUser = Read-Host "  Enter your msft.ghe.com username (e.g., johndoe_microsoft)"
         }
         if ($emuUser) {
-            $ghAccounts["identity-authnz-teams"] = $emuUser
-            $isLoggedIn = $loggedIn -contains $emuUser
+            $ghAccounts["msft.ghe.com"] = $emuUser
+            $isLoggedIn = (gh auth status --hostname msft.ghe.com 2>&1 | Out-String) -match [regex]::Escape($emuUser)
             if (-not $isLoggedIn) {
-                Write-Host "  Authenticating $emuUser with GitHub..." -ForegroundColor Cyan
-                gh auth login --hostname github.com --git-protocol https --web
+                Write-Host "  Authenticating $emuUser with msft.ghe.com..." -ForegroundColor Cyan
+                gh auth login --hostname msft.ghe.com --git-protocol https --web
             }
         }
     }
 
     # Save developer-local.json
-    if ($ghAccounts["AzureAD"] -and $ghAccounts["identity-authnz-teams"]) {
+    if ($ghAccounts["AzureAD"] -and $ghAccounts["msft.ghe.com"]) {
         $config = @{
             github_accounts = @{
                 AzureAD = $ghAccounts["AzureAD"]
-                "identity-authnz-teams" = $ghAccounts["identity-authnz-teams"]
+                "msft.ghe.com" = $ghAccounts["msft.ghe.com"]
             }
         }
         $configDir = Join-Path $repoRoot ".github"


### PR DESCRIPTION
## What

Broker moved from public GitHub (`github.com/identity-authnz-teams/ad-accounts-for-android`,
referenced as `AzureAD/ad-accounts-for-android` in pipelines) to GitHub Enterprise
`msft.ghe.com/security/ad-accounts-for-android`. This updates every broker reference in the
android-complete meta-repo. `msal` / `common` / `adal` stay on github.com.

## Changes

- **Pipelines (`azure-pipelines/**`)** - broker `repository:` resources: `type: github` /
  `AzureAD/ad-accounts-for-android` / `ANDROID_GITHUB` -> `type: githubenterprise` /
  `security/ad-accounts-for-android` / `MSFT_GHE_SECURITY` (`ref` preserved). 9 files.
- **AI-orchestrator skills/agents/prompts + scripts** - broker slug/URLs -> `security` +
  `msft.ghe.com`; account routing switched from EMU `gh auth switch` to **per-host**
  (`--hostname msft.ghe.com`). `analyze.ps1` / `preflight.ps1` / `precise.ps1` use full-URL
  API bases for all repos (host-routed, no account switching).
- **Setup/docs** - `.gitconfig` (`droidSetup`), `scripts/setup-ai-orchestrator.ps1`,
  `AI Driven Development Guide.md`, `docs/AzureDevOps/Compliance/OSSReviews.md`, and
  `developer-local.json` account key (`identity-authnz-teams` -> `msft.ghe.com`).
- **New** - `docs/broker-remote-migration.md` (teammate runbook) and
  `.github/prompts/broker-ghe-migrate.prompt.md` (`/broker-ghe-migrate` helper).
- Report-template historical broker PR links repointed to GHE (PR numbers were preserved
  in the migration). Historical `changes.txt` links left untouched.

## Prerequisite for reviewers

A pipeline admin must create/authorize the **`MSFT_GHE_SECURITY`** service connection
(GitHub Enterprise Server, `https://msft.ghe.com`, org `security`) before broker-dependent
pipelines can check out. See `docs/broker-remote-migration.md`.

## Not included (intentional)

- `.gitignore` change and the `AuthClientAndroidPipelines/` + `IdentityWiki.wiki/` clones
  are untracked/unstaged and excluded from this PR.

[AB#3699280](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3699280)
